### PR TITLE
whitelisted GBIF CCH2 IPs , blocked rdap bot

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -83,7 +83,7 @@ http {
         CFNetwork/.* Darwin|ClaudeBot|SemrushBot|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Sogou|Exabot|
         facebot|facebookexternalhit|Bytespider|AppleBot|Swiftbot|Slurp Bot|CCBot|GoogleOther|Google-InspectionTool|
         MJ12bot|Alexa crawler|Soso Spider|Pinterestbot|Dotbot|AhrefsBot|archive.org_bot|scrapy|PetalBot|
-        SemrushBot|Amazonbot|DataForSeoBot|crawl-66-249-66-200.googlebot.com)" 1;
+        SemrushBot|Amazonbot|DataForSeoBot|crawl-66-249-66-200.googlebot.com|rdap.arin.net)" 1;
     }
 
 
@@ -93,6 +93,7 @@ http {
         default 0;
         47.76.0.0/16 1;
         66.249.66.200 1;
+        52.224.0.0/11 1; #rdap arin bot
     }
 
     # Map directive to create exceptions for certain IP ranges
@@ -101,6 +102,8 @@ http {
         10.0.0.0/8 0;       # 24-bit block
         172.16.0.0/12 0;    # 20-bit block
         192.168.0.0/16 0;   # 16-bit block
+        130.225.43.0/24 0;  # gbif servers
+        206.207.50.146 0;   # CCH2 server
     }
 
     map $limited $limit {


### PR DESCRIPTION
Whitelisted CCH2 and GBIF servers.
Blocked rdap.arin.net bot from microsoft