### PR TITLE
 S3 compatibility for server + robots.txt 

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy your main nginx.conf into the container
 COPY nginx.conf /etc/nginx/
+COPY views/robots.txt /srv/app/views/robots.txt
 
 # Download and install the Nginx Ultimate Bad Bot Blocker 'install-ngxblocker' script
 RUN wget https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master/install-ngxblocker \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -6,15 +6,31 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     ca-certificates tzdata wget curl python3-pip python3-setuptools \
     build-essential libffi-dev imagemagick libimage-exiftool-perl \
-    gcc-aarch64-linux-gnu uwsgi uwsgi-plugin-python3 python3.12-venv\
+    gcc-aarch64-linux-gnu uwsgi uwsgi-plugin-python3 python3.12-venv \
+    python3.12-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Create working directory
 WORKDIR /tmp
-# Create virtual environment in a different directory
+
+# Create virtual environment
 RUN python3.12 -m venv venv
 ENV PATH="/tmp/venv/bin:$PATH"
+
+# Add S3 support
 COPY requirements.txt /tmp/requirements.txt
 RUN /tmp/venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt
+RUN /tmp/venv/bin/pip install boto3
+
+# Optional: install AWS CLI for testing/debugging
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && apt-get update && apt-get install -y unzip \
+    && unzip awscliv2.zip && ./aws/install \
+    && rm -rf awscliv2.zip aws
+
+# Set timezone
 ENV TZ=America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Switch to code directory
 WORKDIR /code

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates tzdata wget curl python3-pip python3-setuptools \
     build-essential libffi-dev imagemagick libimage-exiftool-perl \
     gcc-aarch64-linux-gnu uwsgi uwsgi-plugin-python3 python3.12-venv \
-    python3.12-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create working directory
@@ -20,13 +19,6 @@ ENV PATH="/tmp/venv/bin:$PATH"
 # Add S3 support
 COPY requirements.txt /tmp/requirements.txt
 RUN /tmp/venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt
-RUN /tmp/venv/bin/pip install boto3
-
-# Optional: install AWS CLI for testing/debugging
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && apt-get update && apt-get install -y unzip \
-    && unzip awscliv2.zip && ./aws/install \
-    && rm -rf awscliv2.zip aws
 
 # Set timezone
 ENV TZ=America/Los_Angeles

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -34,3 +34,13 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Switch to code directory
 WORKDIR /code
+
+# copy and mark entrypoint
+#COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+#RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Make entrypoint.sh the container's entrypoint
+#ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# The CMD will be passed as "$@" to entrypoint.sh
+#CMD ["uwsgi", "--plugin", "/usr/lib/uwsgi/plugins/python312_plugin.so", "--ini", "uwsgi.ini"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -34,13 +34,3 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Switch to code directory
 WORKDIR /code
-
-# copy and mark entrypoint
-#COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-#RUN chmod +x /usr/local/bin/entrypoint.sh
-
-# Make entrypoint.sh the container's entrypoint
-#ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-
-# The CMD will be passed as "$@" to entrypoint.sh
-#CMD ["uwsgi", "--plugin", "/usr/lib/uwsgi/plugins/python312_plugin.so", "--ini", "uwsgi.ini"]

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -29,15 +29,16 @@ services:
       - PYTHONUNBUFFERED=1
       - LANG=C.UTF-8
       # MinIO / S3 settings, comment out if not using
-      - S3_ENDPOINT=https://your_url
-      - S3_BUCKET=attachments
-      - S3_ACCESS_KEY=ACCESS_KEY
-      - S3_SECRET_KEY=YOUR_SECRET_KEY
-      - S3_URL_EXPIRY=3600
-      - S3_REGION=us-east-1
+      #- S3_ENDPOINT=https://your_url
+      #- S3_BUCKET=attachments
+      #- S3_ACCESS_KEY=ACCESS_KEY
+      #- S3_SECRET_KEY=YOUR_SECRET_KEY
+      #- S3_URL_EXPIRY=3600
+      #- S3_REGION=us-east-1
     volumes:
       - ./:/code
-      # - /path/to/external/attachments/mount:/code/attachments
+      # comment out if enabling S3 above
+      - /path/to/external/attachments/mount:/code/attachments
     command: ['uwsgi', '--plugin', '/usr/lib/uwsgi/plugins/python312_plugin.so','--ini', 'uwsgi.ini']
 
     restart: always

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -28,6 +28,14 @@ services:
       - EXTERNAL_IP=institution.org
       - PYTHONUNBUFFERED=1
       - LANG=C.UTF-8
+      # enable S3-backed storage
+      - USE_S3=true
+      # MinIO / S3 settings
+      - S3_ENDPOINT=https://your_url
+      - S3_BUCKET=attachments
+      - S3_ACCESS_KEY=ACCESS_KEY
+      - S3_SECRET_KEY=YOUR_SECRET_KEY
+      - S3_URL_EXPIRY=3600
     volumes:
       - ./:/code
     command: ['uwsgi', '--plugin', '/usr/lib/uwsgi/plugins/python312_plugin.so','--ini', 'uwsgi.ini']

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -28,16 +28,16 @@ services:
       - EXTERNAL_IP=institution.org
       - PYTHONUNBUFFERED=1
       - LANG=C.UTF-8
-      # enable S3-backed storage
-      - USE_S3=true
-      # MinIO / S3 settings
+      # MinIO / S3 settings, comment out if not using
       - S3_ENDPOINT=https://your_url
       - S3_BUCKET=attachments
       - S3_ACCESS_KEY=ACCESS_KEY
       - S3_SECRET_KEY=YOUR_SECRET_KEY
       - S3_URL_EXPIRY=3600
+      - S3_REGION=us-east-1
     volumes:
       - ./:/code
+      # - /path/to/external/attachments/mount:/code/attachments
     command: ['uwsgi', '--plugin', '/usr/lib/uwsgi/plugins/python312_plugin.so','--ini', 'uwsgi.ini']
 
     restart: always

--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -137,6 +137,12 @@ http {
         ssl_certificate /etc/ssl/certs/name_of_ssl_cert.pem;
         ssl_certificate_key /etc/ssl/private/name_of_ssl_cert.key;
 
+        location = /robots.txt {
+            default_type text/plain;
+            add_header Cache-Control "max-age=3600, public";
+            alias /srv/app/views/robots.txt;
+        }
+
 
         # include /etc/nginx/bots.d/blockbots.conf;
         # include /etc/nginx/bots.d/ddos.conf;

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pluggy~=1.5.0
 pyparsing~=3.0.9
 pytest~=8.3.3
 pytz~=2024.2
-requests==2.32.0
+requests==2.32.4
 retrying~=1.3.4
 sh~=2.0.4
 six==1.16.0
@@ -57,3 +57,5 @@ pillow~=10.3.0
 wrapt-timeout-decorator~=1.5.1
 testfixtures~=8.3.0
 cas-metadata-tools~=1.0.1
+boto3~=1.39.2
+botocore~=1.39.2

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -1,0 +1,171 @@
+# s3_server_utils.py
+import os
+import tempfile
+from functools import lru_cache
+from contextlib import contextmanager
+from os import path, makedirs, remove
+
+import boto3
+from botocore.exceptions import ClientError
+from bottle import abort
+
+import settings  # assumes settings.py is accessible
+
+
+# --- S3 configuration flags / environment ------------------------------------
+USE_S3 = os.getenv('USE_S3', 'false').lower() in ('1', 'true', 'yes')
+
+if USE_S3:
+    S3_ENDPOINT   = os.getenv('S3_ENDPOINT')
+    S3_BUCKET     = os.getenv('S3_BUCKET')
+    S3_ACCESS_KEY = os.getenv('S3_ACCESS_KEY')
+    S3_SECRET_KEY = os.getenv('S3_SECRET_KEY')
+    S3_URL_EXPIRY = int(os.getenv('S3_URL_EXPIRY', '3600'))
+    S3_REGION     = os.getenv('S3_REGION')
+else:
+    # Provide defaults so attribute access does not fail when S3 disabled
+    S3_ENDPOINT = S3_BUCKET = S3_ACCESS_KEY = S3_SECRET_KEY = S3_REGION = None
+    S3_URL_EXPIRY = 0
+
+
+# --- Internal helpers ---------------------------------------------------------
+def s3_key(p: str) -> str:
+    """Normalize a path into an S3 object key."""
+    return p.lstrip('/')
+
+
+@lru_cache(maxsize=1)
+def get_s3():
+    """Lazy-initialized singleton S3 client (only if USE_S3)."""
+    if not USE_S3:
+        raise RuntimeError("S3 is not enabled")
+    session = boto3.session.Session()
+    s3 = session.client(
+        's3',
+        endpoint_url=S3_ENDPOINT,
+        aws_access_key_id=S3_ACCESS_KEY,
+        aws_secret_access_key=S3_SECRET_KEY,
+        region_name=S3_REGION
+    )
+    # Ensure bucket exists
+    try:
+        s3.head_bucket(Bucket=S3_BUCKET)
+    except ClientError as e:
+        code = e.response['Error']['Code']
+        if code in ('404', 'NoSuchBucket'):
+            s3.create_bucket(Bucket=S3_BUCKET)
+        else:
+            raise
+    return s3
+
+
+# --- Public storage abstraction API ------------------------------------------
+def storage_exists(rel: str) -> bool:
+    """
+    Check if object exists locally or in S3.
+    rel: relative path/key (no base directory).
+    """
+    local_path = os.path.join(settings.BASE_DIR, rel)
+    if path.exists(local_path):
+        return True
+    if USE_S3:
+        try:
+            get_s3().head_object(Bucket=S3_BUCKET, Key=s3_key(rel))
+            return True
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                return False
+            raise
+    return False
+
+
+def orig_location(rel: str) -> str:
+    """
+    Validate that the original exists (S3 mode) before returning rel key/path.
+    """
+    if USE_S3 and not storage_exists(rel):
+        abort(404, f"Missing object: {rel}")
+    return rel
+
+
+@contextmanager
+def storage_tempfile(rel: str):
+    """
+    Context manager yielding a local temp filename with remote/S3 object
+    downloaded. File is removed afterward.
+    """
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    get_s3().download_file(S3_BUCKET, s3_key(rel), tmp.name)
+    try:
+        yield tmp.name
+    finally:
+        try:
+            os.remove(tmp.name)
+        except OSError:
+            pass
+
+
+def storage_download(rel: str) -> str:
+    """
+    Return a local file path to the given relative key/path. If local file
+    exists, returns it; otherwise downloads from S3 to a temp file.
+    """
+    local = path.join(settings.BASE_DIR, rel)
+    if path.exists(local):
+        return local
+    if USE_S3:
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        get_s3().download_file(S3_BUCKET, s3_key(rel), tmp.name)
+        return tmp.name
+    abort(404)
+
+
+def storage_save(rel: str, file_object):
+    """
+    Save file data either to local filesystem or S3.
+    file_object must be a file-like object.
+    """
+    local = path.join(settings.BASE_DIR, rel)
+    local_dir = path.dirname(local)
+    # If local mode OR destination directory already exists locally, save local
+    if path.isdir(local_dir) or not USE_S3:
+        makedirs(local_dir, exist_ok=True)
+        with open(local, 'wb') as o:
+            o.write(file_object.read())
+        return
+    # S3
+    file_object.seek(0)
+    get_s3().put_object(Bucket=S3_BUCKET, Key=s3_key(rel), Body=file_object.read())
+
+
+def storage_delete(rel: str):
+    """
+    Delete the object referenced by rel from local filesystem or S3.
+    """
+    local = path.join(settings.BASE_DIR, rel)
+    if path.exists(local):
+        remove(local)
+        return
+    if USE_S3:
+        get_s3().delete_object(Bucket=S3_BUCKET, Key=s3_key(rel))
+        return
+    abort(404)
+
+
+def storage_url(rel: str):
+    """
+    Generate a presigned URL for an S3 object if running in S3 mode and the
+    object is not found locally. Returns None for local files.
+    """
+    local = path.join(settings.BASE_DIR, rel)
+    if path.exists(local):
+        return None
+    if USE_S3:
+        return get_s3().generate_presigned_url(
+            'get_object',
+            Params={'Bucket': S3_BUCKET, 'Key': s3_key(rel)},
+            ExpiresIn=S3_URL_EXPIRY
+        )
+    return None

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -4,7 +4,7 @@ import tempfile
 from functools import lru_cache
 from contextlib import contextmanager
 from os import path, makedirs, remove
-
+import logging
 import boto3
 from botocore.exceptions import ClientError
 from bottle import abort
@@ -100,11 +100,18 @@ def storage_tempfile(rel: str):
     try:
         yield tmp.name
     finally:
-        try:
-            os.remove(tmp.name)
-        except OSError:
-            pass
+        remove_tempfile(tmp.name)
 
+
+def remove_tempfile(tmp_path: str):
+    """
+    removes temp-files created by the storage download with exception
+    """
+    if os.path.exists(tmp_path):
+        try:
+            os.remove(tmp_path)
+        except OSError as e:
+            logging.warning(f"Could not delete {tmp_path}: {e}")
 
 def storage_download(rel: str) -> str:
     """

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -1,4 +1,5 @@
-# s3_server_utils.py
+"""docstring s3_server_utils.py: used to enable for s3 api compatibility for server.py.
+Variables for s3 api set in docker-compose.yml as environment variables"""
 import os
 import shutil
 import sys
@@ -7,185 +8,226 @@ from functools import lru_cache
 from contextlib import contextmanager
 from os import path, makedirs, remove
 import logging
-import socket
-from urllib.parse import urlparse
+from mimetypes import guess_type
 import boto3
 from botocore.exceptions import ClientError
+from urllib.parse import quote
+from bottle import HTTPResponse
 from bottle import abort
 import time
 import settings
 
-if os.getenv('S3_ENDPOINT'):
-    S3_ENDPOINT   = os.getenv('S3_ENDPOINT')
-    S3_BUCKET     = os.getenv('S3_BUCKET')
-    S3_ACCESS_KEY = os.getenv('S3_ACCESS_KEY')
-    S3_SECRET_KEY = os.getenv('S3_SECRET_KEY')
-    S3_URL_EXPIRY = int(os.getenv('S3_URL_EXPIRY', '3600'))
-    S3_REGION     = os.getenv('S3_REGION')
-    TMP_FOLDER = "s3_temp"
 
-    if os.path.isdir(TMP_FOLDER):
-        # clearing out any temp undeleted temp files on startup
-        shutil.rmtree(TMP_FOLDER)
-    os.makedirs(TMP_FOLDER, exist_ok=True)
-else:
-    # Provide defaults so attribute access does not fail when S3 disabled
-    S3_ENDPOINT = S3_BUCKET = S3_ACCESS_KEY = S3_SECRET_KEY = S3_REGION = None
-    S3_URL_EXPIRY = 0
 
+class S3Connection():
+    def __init__(self):
+        if os.getenv('S3_ENDPOINT'):
+            self.S3_ENDPOINT   = os.getenv('S3_ENDPOINT')
+            self.S3_BUCKET     = os.getenv('S3_BUCKET')
+            self.S3_ACCESS_KEY = os.getenv('S3_ACCESS_KEY')
+            self.S3_SECRET_KEY = os.getenv('S3_SECRET_KEY')
+            self.S3_URL_EXPIRY = int(os.getenv('S3_URL_EXPIRY', '3600'))
+            self.S3_REGION     = os.getenv('S3_REGION')
+            self.TMP_FOLDER = "s3_temp"
+        else:
+            # Provide defaults so attribute access does not fail when S3 disabled
+            self.S3_ENDPOINT = self.S3_BUCKET = self.S3_ACCESS_KEY = self.S3_SECRET_KEY = self.S3_REGION = None
+            self.S3_URL_EXPIRY = 0
+        self.chunk_size = 64 * 1024
+        self.make_temp_folder()
+
+    def make_temp_folder(self):
+        """creates and cleans out folder for storage of temp images"""
+        os.makedirs(self.TMP_FOLDER, exist_ok=True)
+
+        for name in os.listdir(self.TMP_FOLDER):
+            path = os.path.join(self.TMP_FOLDER, name)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
 
 # --- Internal helpers ---------------------------------------------------------
-def s3_key(p: str) -> str:
-    """Normalize a path into an S3 object key."""
-    return p.lstrip('/')
+    def s3_key(self, p: str) -> str:
+        """Normalize a path into an S3 object key."""
+        return p.lstrip('/')
 
-@lru_cache(maxsize=1)
-def get_s3():
-    """Lazy-initialized singleton S3 client (only if USE_S3)."""
-    if not S3_ENDPOINT:
-        raise RuntimeError("S3 is not enabled")
-    session = boto3.session.Session()
-    s3 = session.client(
-        's3',
-        endpoint_url=S3_ENDPOINT,
-        aws_access_key_id=S3_ACCESS_KEY,
-        aws_secret_access_key=S3_SECRET_KEY,
-        region_name=S3_REGION
-    )
-    # Ensure bucket exists
-    try:
-        s3.head_bucket(Bucket=S3_BUCKET)
-    except ClientError as e:
-        code = e.response['Error']['Code']
-        if code in ('404', 'NoSuchBucket'):
-            try:
-                s3.create_bucket(Bucket=S3_BUCKET)
-                time.sleep(10)
-                s3.head_bucket(Bucket=S3_BUCKET)
-            except ClientError as e:
-                logging.critical(f"Bucket {S3_BUCKET} does not exist and could not be created.", e)
-                sys.exit()
-        else:
-            logging.critical(f"Bucket {S3_BUCKET} does not exist and could not be created.", e)
-            sys.exit()
-    return s3
-
-
-# --- Public storage abstraction API ------------------------------------------
-def storage_exists(rel: str) -> bool:
-    """
-    Check if object exists locally or in S3.
-    rel: relative path/key (no base directory).
-    """
-    local_path = os.path.join(settings.BASE_DIR, rel)
-    if path.exists(local_path):
-        return True
-    if S3_ENDPOINT:
-        try:
-            get_s3().head_object(Bucket=S3_BUCKET, Key=s3_key(rel))
-            return True
-        except ClientError as e:
-            if e.response['Error']['Code'] == '404':
-                return False
-            raise
-    return False
-
-
-def orig_location(rel: str) -> str:
-    """
-    Validate that the original exists (S3 mode) before returning rel key/path.
-    """
-    if S3_ENDPOINT and not storage_exists(rel):
-        abort(404, f"Missing object: {rel}")
-    return rel
-
-
-@contextmanager
-def storage_tempfile(rel: str):
-    """
-    Yield a temp file path (under TMP_FOLDER) containing the downloaded S3 object.
-    File is deleted on exit.
-    """
-    _, ext = os.path.splitext(rel)
-    fd, tmp_path = tempfile.mkstemp(dir=TMP_FOLDER, prefix="s3dl_", suffix=ext or "")
-    os.close(fd)
-    try:
-        get_s3().download_file(S3_BUCKET, s3_key(rel), tmp_path)
-        yield tmp_path
-    finally:
-        remove_tempfile(tmp_path)
-
-def remove_tempfile(tmp_path: str):
-    """
-    removes temp-files created by the storage download with exception
-    """
-    tmp_path = os.path.join(tmp_path)
-    if os.path.exists(tmp_path):
-        try:
-            os.remove(tmp_path)
-        except OSError as e:
-            logging.warning(f"Could not delete {tmp_path}: {e}")
-
-def storage_download(rel: str) -> str:
-    """
-    Return a local file path to the given relative key/path. If local file
-    exists, returns it; otherwise downloads from S3 to a temp file.
-    """
-    local = path.join(settings.BASE_DIR, rel)
-    if path.exists(local):
-        return local
-    if S3_ENDPOINT:
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.close()
-        get_s3().download_file(S3_BUCKET, s3_key(rel), tmp.name)
-        return tmp.name
-    abort(404)
-
-
-def storage_save(rel: str, file_object):
-    """
-    Save file data either to local filesystem or S3.
-    file_object must be a file-like object.
-    """
-    local = path.join(settings.BASE_DIR, rel)
-    local_dir = path.dirname(local)
-    # If local mode OR destination directory already exists locally, save local
-    if path.isdir(local_dir) or not S3_ENDPOINT:
-        makedirs(local_dir, exist_ok=True)
-        with open(local, 'wb') as o:
-            o.write(file_object.read())
-        return
-    # S3
-    file_object.seek(0)
-    get_s3().put_object(Bucket=S3_BUCKET, Key=s3_key(rel), Body=file_object.read())
-
-
-def storage_delete(rel: str):
-    """
-    Delete the object referenced by rel from local filesystem or S3.
-    """
-    local = path.join(settings.BASE_DIR, rel)
-    if path.exists(local):
-        remove(local)
-        return
-    if S3_ENDPOINT:
-        get_s3().delete_object(Bucket=S3_BUCKET, Key=s3_key(rel))
-        return
-    abort(404)
-
-
-def storage_url(rel: str):
-    """
-    Generate a presigned URL for an S3 object if running in S3 mode and the
-    object is not found locally. Returns None for local files.
-    """
-    local = path.join(settings.BASE_DIR, rel)
-    if path.exists(local):
-        return None
-    if S3_ENDPOINT:
-        return get_s3().generate_presigned_url(
-            'get_object',
-            Params={'Bucket': S3_BUCKET, 'Key': s3_key(rel)},
-            ExpiresIn=S3_URL_EXPIRY
+    @lru_cache(maxsize=1)
+    def get_s3(self):
+        """Lazy-initialized singleton S3 client (only if USE_S3)."""
+        if not self.S3_ENDPOINT:
+            raise RuntimeError("S3 is not enabled")
+        session = boto3.session.Session()
+        s3 = session.client(
+            's3',
+            endpoint_url=self.S3_ENDPOINT,
+            aws_access_key_id=self.S3_ACCESS_KEY,
+            aws_secret_access_key=self.S3_SECRET_KEY,
+            region_name=self.S3_REGION
         )
-    return None
+        # Ensure bucket exists
+        try:
+            s3.head_bucket(Bucket=self.S3_BUCKET)
+        except ClientError as e:
+            code = e.response['Error']['Code']
+            if code in ('404', 'NoSuchBucket'):
+                try:
+                    s3.create_bucket(Bucket=self.S3_BUCKET)
+                    time.sleep(10)
+                    s3.head_bucket(Bucket=self.S3_BUCKET)
+                except ClientError as e:
+                    logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
+                    sys.exit()
+            else:
+                logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
+                sys.exit()
+        return s3
+
+
+    # --- Public storage abstraction API ------------------------------------------
+    def storage_exists(self, rel: str) -> bool:
+        """
+        Check if object exists locally or in S3.
+        rel: relative path/key (no base directory).
+        """
+        local_path = os.path.join(settings.BASE_DIR, rel)
+        if path.exists(local_path):
+            return True
+        if self.S3_ENDPOINT:
+            try:
+                self.get_s3().head_object(Bucket=self.S3_BUCKET, Key=self.s3_key(rel))
+                return True
+            except ClientError as e:
+                if e.response['Error']['Code'] == '404':
+                    return False
+                raise
+        return False
+
+
+    def orig_location(self, rel: str) -> str:
+        """
+        Validate that the original exists (S3 mode) before returning rel key/path.
+        """
+        if self.S3_ENDPOINT and not self.storage_exists(rel):
+            abort(404, f"Missing object: {rel}")
+        return rel
+
+
+    @contextmanager
+    def storage_tempfile(self, rel: str):
+        """
+        Yield a temp file path (under TMP_FOLDER) containing the downloaded S3 object.
+        File is deleted on exit.
+        """
+        _, ext = os.path.splitext(rel)
+        fd, tmp_path = tempfile.mkstemp(dir=self.TMP_FOLDER, prefix="s3dl_", suffix=ext or "")
+        os.close(fd)
+        try:
+            self.get_s3().download_file(self.S3_BUCKET, self.s3_key(rel), tmp_path)
+            yield tmp_path
+        finally:
+            self.remove_tempfile(tmp_path)
+
+    def remove_tempfile(self, tmp_path: str):
+        """
+        removes temp-files created by the storage download with exception
+        """
+        tmp_path = os.path.join(tmp_path)
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError as e:
+                logging.warning(f"Could not delete {tmp_path}: {e}")
+
+    def storage_download(self, rel: str) -> str:
+        """
+        Return a local file path to the given relative key/path. If local file
+        exists, returns it; otherwise downloads from S3 to a temp file.
+        """
+        local = path.join(settings.BASE_DIR, rel)
+        if path.exists(local):
+            return local
+        if self.S3_ENDPOINT:
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            tmp.close()
+            self.get_s3().download_file(self.S3_BUCKET, self.s3_key(rel), tmp.name)
+            return tmp.name
+        abort(404)
+
+
+    def storage_save(self, rel: str, file_object):
+        """
+        Save file data either to local filesystem or S3.
+        file_object must be a file-like object.
+        """
+        local = path.join(settings.BASE_DIR, rel)
+        local_dir = path.dirname(local)
+        # If local mode OR destination directory already exists locally, save local
+        if path.isdir(local_dir) or not self.S3_ENDPOINT:
+            makedirs(local_dir, exist_ok=True)
+            with open(local, 'wb') as o:
+                o.write(file_object.read())
+            return
+        # S3
+        file_object.seek(0)
+        self.get_s3().put_object(Bucket=self.S3_BUCKET, Key=self.s3_key(rel), Body=file_object.read())
+
+
+    def storage_delete(self, rel: str):
+        """
+        Delete the object referenced by rel from local filesystem or S3.
+        """
+        local = path.join(settings.BASE_DIR, rel)
+        if path.exists(local):
+            remove(local)
+            return
+        if self.S3_ENDPOINT:
+            self.get_s3().delete_object(Bucket=self.S3_BUCKET, Key=self.s3_key(rel))
+            return
+        abort(404)
+
+
+    def storage_url(self, rel: str):
+        """
+        Generate a pre-signed URL for an S3 object if running in S3 mode and the
+        object is not found locally. Returns None for local files.
+        """
+        local = path.join(settings.BASE_DIR, rel)
+        if path.exists(local):
+            return None
+        if self.S3_ENDPOINT:
+            return self.get_s3().generate_presigned_url(
+                'get_object',
+                Params={'Bucket': self.S3_BUCKET, 'Key': self.s3_key(rel)},
+                ExpiresIn=self.S3_URL_EXPIRY
+            )
+        return None
+
+
+
+    def stream(self, body):
+        """loads the stream by iterating through the file body by chunk size"""
+        try:
+            for chunk in iter(lambda: body.read(self.chunk_size), b''):
+                yield chunk
+        finally:
+            body.close()
+
+    def s3_stream_response(self, key, downloadname=None, filename_for_ct=None):
+        """streams s3 response, allowing for no static storage usage."""
+        s3 = self.get_s3()
+        head = s3.head_object(Bucket=self.S3_BUCKET, Key=self.s3_key(key))
+        obj = s3.get_object(Bucket=self.S3_BUCKET, Key=self.s3_key(key))
+        body = obj["Body"]  # botocore.response.StreamingBody
+
+        mime, _ = guess_type(filename_for_ct or key)
+        ctype = mime or head.get('ContentType', 'application/octet-stream')
+        # Inline unless caller asked for a download name
+        dn = downloadname or filename_for_ct or os.path.basename(key)
+        dn_q = quote(os.path.basename(dn).encode('ascii', 'replace'))
+
+        r = HTTPResponse(body=self.stream(body=body))
+        r.set_header('Content-Type', ctype)
+        r.set_header('Content-Length', str(head['ContentLength']))
+        r.set_header('Content-Disposition', f"inline; filename*=utf-8''{dn_q}")
+        return r

--- a/server.py
+++ b/server.py
@@ -791,6 +791,15 @@ def web_asset_store():
     return template('web_asset_store.xml', host="%s:%d" % (settings.SERVER_NAME, settings.SERVER_PORT),
                     protocol=settings.SERVER_PROTOCOL)
 
+@app.route('/robots.txt')
+@include_timestamp
+def retrieve_robots_txt():
+    """serve a txt file describing permitted bot and webcrawler access"""
+    response.content_type = 'text/plain; charset=utf-8'
+    root = os.path.join(os.path.dirname(__file__), 'views')
+    return static_file('robots.txt', root=root, mimetype='text/plain')
+
+
 @app.route('/')
 def main_page():
     log("Hit root")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -89,9 +89,6 @@ def test_web_asset_store():
     response = requests.get(build_url(endpoint))
     assert response.status_code == 200
     result = response.content.decode("utf-8")
-    print(body)
-    print("______________")
-    print(result)
     assert body == result
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -83,12 +83,15 @@ def test_web_asset_store():
     <url type="delete"><![CDATA[{settings.SERVER_PROTOCOL}://{settings.SERVER_NAME}:{settings.SERVER_PORT}/filedelete]]></url>
     <url type="getexifdata"><![CDATA[{settings.SERVER_PROTOCOL}://{settings.SERVER_NAME}:{settings.SERVER_PORT}/getexifdata]]></url>
     <url type="testkey">{settings.SERVER_PROTOCOL}://{settings.SERVER_NAME}:{settings.SERVER_PORT}/testkey</url>
-</urls>
-"""
+</urls>"""
+
     endpoint = "web_asset_store.xml"
     response = requests.get(build_url(endpoint))
     assert response.status_code == 200
     result = response.content.decode("utf-8")
+    print(body)
+    print("______________")
+    print(result)
     assert body == result
 
 

--- a/views/robots.txt
+++ b/views/robots.txt
@@ -1,0 +1,36 @@
+# disallowing all bots and webcrawlers
+
+User-agent: *
+Disallow: /
+
+## exceptions
+
+# www.cch2.org
+User-agent: *www.cch2.org*
+Allow: /
+
+# bryophyteportal.org
+User-agent: *bryophyteportal.org*
+Allow: /
+
+# lichenportal.org
+User-agent: *lichenportal.org*
+Allow: /
+
+# library.big‑bee.net
+User-agent: *library.big‑bee.net*
+Allow: /
+
+# GBIF API crawler
+User-agent: *api.gbif.org*
+Allow: /
+
+# GBIF scientific‑collections
+User-agent: *scientific‑collections.gbif.org*
+Allow: /
+
+# Thumbor v7.4.7 from Danmarks Tekniske Universitet
+User-agent: *Thumbor/7.4.7*
+Allow: /
+
+


### PR DESCRIPTION
files changed:
docker-compose.template.yml: added environment variables for s3

server.py: added logic to work for both s3 and standard mount configurations

New files:
s3_server_utils.py: split off the s3 server functions for , upload, delete, cleanup , connections etc.. to avoid creating a "god module" in the main server.py with too many functions. These are imported directly into the server

robots.txt: outline of server rules for bots, and noted exceptions