### PR TITLE
Fix Content-Type headers, rate limiting, and add DB indexes

### DIFF
--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -183,7 +183,15 @@ http {
         default "";
     }
 
-    limit_req_zone $final_limit zone=image_zone:10m rate=6r/m;
+    # Thumbnail requests (type=T) bypass rate limiting entirely.
+    # Full-size requests are still rate-limited for external IPs.
+    map $arg_type $fullsize_limit {
+        "T"     "";
+        default $final_limit;
+    }
+
+    limit_req_zone $fullsize_limit zone=thumb_zone:10m rate=120r/m;
+    limit_req_zone $fullsize_limit zone=fullsize_zone:10m rate=30r/m;
 
     # If Ultimate Bad Bot Blocker is installed
     include /etc/nginx/conf.d/globalblacklist.conf;
@@ -265,6 +273,29 @@ http {
             # SigV4 signing for MinIO
             access_by_lua_file /usr/local/openresty/nginx/lua/s3_sign.lua;
 
+            # Override Content-Type based on file extension.
+            # MinIO often stores files as binary/octet-stream regardless of
+            # actual type, which breaks browser rendering and iDigBio harvesting.
+            header_filter_by_lua_block {
+                local key = ngx.var.key or ""
+                local ext = key:match("%.([^%.]+)$")
+                if ext then
+                    ext = ext:lower()
+                    local types = {
+                        jpg  = "image/jpeg",
+                        jpeg = "image/jpeg",
+                        png  = "image/png",
+                        gif  = "image/gif",
+                        tif  = "image/tiff",
+                        tiff = "image/tiff",
+                        pdf  = "application/pdf",
+                    }
+                    if types[ext] then
+                        ngx.header["Content-Type"] = types[ext]
+                    end
+                end
+            }
+
             # Do not forward dn/disp query args to MinIO
             proxy_pass $s3_scheme://$s3_host:$s3_port/$bucket/$key;
         }
@@ -279,7 +310,16 @@ http {
                 return 204;
             }
 
-            limit_req zone=image_zone burst=2 nodelay;
+            limit_req zone=thumb_zone burst=120 nodelay;
+            limit_req zone=fullsize_zone burst=10 nodelay;
+
+            # Decode &amp; -> & in query strings (Specify encodes ampersands as HTML entities)
+            rewrite_by_lua_block {
+                local args = ngx.var.args
+                if args and args:find("&amp;", 1, true) then
+                    ngx.req.set_uri_args((args:gsub("&amp;", "&")))
+                end
+            }
 
             try_files $uri @image-server;
         }

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -279,7 +279,11 @@ class S3Connection:
         """
         full_key = self.s3_full_key(rel)
         file_object.seek(0)
-        self.get_s3().put_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key), Body=file_object.read())
+        mime, _ = guess_type(full_key)
+        kwargs = dict(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key), Body=file_object.read())
+        if mime:
+            kwargs["ContentType"] = mime
+        self.get_s3().put_object(**kwargs)
 
     @retry_s3_call()
     def storage_delete(self, rel: str):


### PR DESCRIPTION
## Summary

- **Content-Type headers**: Override MinIO default binary/octet-stream with correct MIME types at both upload and serve time. Fixes browser rendering and iDigBio harvesting.
- **Rate limiting overhaul**: Thumbnail requests (type=T) bypass rate limiting. Full-size requests get separate zones (120r/m thumbs, 30r/m full-size, up from 6r/m blanket).
- **URL decoding fix**: Decode &amp; to & in query strings for Specify clients that HTML-encode ampersands.
- **Database indexes**: Auto-create indexes on internal_filename, orig_md5, collection, and original_filename for query performance.

## Test plan

- [ ] Verify thumbnail requests are not rate-limited
- [ ] Verify full-size image requests are rate-limited at new thresholds
- [ ] Confirm Content-Type headers are correct for jpg/png/tiff/pdf responses
- [ ] Confirm encoded query strings resolve correctly
- [ ] Check database indexes are created on first startup