### PR TITLE
Fix fork deadlocks, connection pool leaks, and worker saturation

### DIFF
--- a/image_cache.py
+++ b/image_cache.py
@@ -29,7 +29,8 @@ CACHE_INVALIDATE_PATH = '/tmp/image_cache.invalidate'
 
 _check_lock = threading.Lock()
 _last_check_monotonic = 0.0
-_CHECK_INTERVAL_S = 60
+_CHECK_INTERVAL_S = 10     # how often workers stat() the marker file
+_DEBOUNCE_S = 30           # wait for writes to quiesce before rebuilding
 
 
 # ── build / rebuild ────────────────────────────────────────────────
@@ -159,10 +160,16 @@ def _needs_rebuild():
     if not os.path.exists(CACHE_DB_PATH):
         return True
     try:
-        os.stat(CACHE_INVALIDATE_PATH)
-        return True
+        marker_mtime = os.stat(CACHE_INVALIDATE_PATH).st_mtime
     except FileNotFoundError:
         return False
+    # Debounce: don't rebuild while writes are still arriving.
+    # Only rebuild once the marker is older than _DEBOUNCE_S,
+    # meaning writes have quiesced.
+    age = time.time() - marker_mtime
+    if age < _DEBOUNCE_S:
+        return False  # too fresh — writes still in progress
+    return True
 
 
 def _ensure_cache():

--- a/image_cache.py
+++ b/image_cache.py
@@ -1,0 +1,272 @@
+"""SQLite-based read cache for the images table.
+
+Eliminates MySQL from the hot read path.  The cache is a SQLite file
+at /tmp/image_cache.db, rebuilt from MySQL periodically.  All 32 uWSGI
+workers share the same physical pages via OS page cache — near-zero
+per-worker memory overhead.
+
+Rebuild triggers:
+  - First request when the file doesn't exist
+  - A marker file signals invalidation after writes
+  - Periodic check every 60 s
+
+Every public function returns None on failure, signalling the caller
+to fall back to MySQL.
+"""
+
+import fcntl
+import logging
+import os
+import sqlite3
+import time
+import threading
+
+from image_db import _get_pool, TIME_FORMAT_NO_OFFSET
+
+CACHE_DB_PATH = '/tmp/image_cache.db'
+CACHE_LOCK_PATH = '/tmp/image_cache.lock'
+CACHE_INVALIDATE_PATH = '/tmp/image_cache.invalidate'
+
+_check_lock = threading.Lock()
+_last_check_monotonic = 0.0
+_CHECK_INTERVAL_S = 60
+
+
+# ── build / rebuild ────────────────────────────────────────────────
+
+def _build_cache_db():
+    """Full rebuild: MySQL → SQLite temp file → atomic rename."""
+    t0 = time.monotonic()
+    tmp_path = CACHE_DB_PATH + '.tmp.' + str(os.getpid())
+
+    conn = sqlite3.connect(tmp_path)
+    conn.execute('PRAGMA journal_mode=OFF')
+    conn.execute('PRAGMA synchronous=OFF')
+    conn.execute('PRAGMA cache_size=-65536')  # 64 MB page cache during build
+    conn.execute('''CREATE TABLE images (
+        id          INTEGER PRIMARY KEY,
+        original_filename  TEXT,
+        url                TEXT,
+        universal_url      TEXT,
+        internal_filename  TEXT,
+        collection         TEXT,
+        original_path      TEXT,
+        notes              TEXT,
+        redacted           INTEGER,
+        datetime           TEXT,
+        orig_md5           TEXT
+    )''')
+
+    # Stream rows from MySQL in server-side cursor fashion
+    pool = _get_pool()
+    cnx = pool.get_connection()
+    row_count = 0
+    try:
+        cursor = cnx.cursor(buffered=False)  # unbuffered — stream rows
+        cursor.execute(
+            "SELECT id, original_filename, url, universal_url, "
+            "internal_filename, collection, original_path, notes, "
+            "redacted, `datetime`, orig_md5 FROM images"
+        )
+        batch = []
+        for row in cursor:
+            dt = row[9]
+            if dt is not None and not isinstance(dt, str):
+                dt = dt.strftime(TIME_FORMAT_NO_OFFSET)
+            batch.append((
+                row[0], row[1], row[2], row[3], row[4],
+                row[5], row[6], row[7], row[8], dt, row[10]
+            ))
+            if len(batch) >= 50000:
+                conn.executemany(
+                    'INSERT INTO images VALUES (?,?,?,?,?,?,?,?,?,?,?)', batch
+                )
+                row_count += len(batch)
+                batch = []
+        if batch:
+            conn.executemany(
+                'INSERT INTO images VALUES (?,?,?,?,?,?,?,?,?,?,?)', batch
+            )
+            row_count += len(batch)
+        cursor.close()
+    finally:
+        cnx.close()
+
+    conn.execute(
+        'CREATE INDEX idx_cache_internal_filename ON images(internal_filename)'
+    )
+    conn.execute(
+        'CREATE INDEX idx_cache_original_filename ON images(original_filename)'
+    )
+    conn.execute(
+        'CREATE INDEX idx_cache_original_path ON images(original_path)'
+    )
+    conn.execute(
+        'CREATE INDEX idx_cache_orig_md5 ON images(orig_md5)'
+    )
+    conn.execute(
+        'CREATE INDEX idx_cache_collection ON images(collection)'
+    )
+    conn.commit()
+    conn.close()
+
+    os.replace(tmp_path, CACHE_DB_PATH)
+    # Clear invalidation marker
+    try:
+        os.unlink(CACHE_INVALIDATE_PATH)
+    except FileNotFoundError:
+        pass
+
+    elapsed = round((time.monotonic() - t0) * 1000)
+    logging.info(f"IMAGE_CACHE rebuilt: {row_count} rows in {elapsed}ms")
+
+
+def rebuild_cache():
+    """Rebuild with file-level locking so only one worker builds at a time."""
+    lock_fd = None
+    try:
+        lock_fd = open(CACHE_LOCK_PATH, 'w')
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # Another process is already building — wait for it to finish
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            return  # The other process wrote the file; we're done
+        _build_cache_db()
+    except Exception as e:
+        logging.error(f"IMAGE_CACHE rebuild failed: {e}")
+    finally:
+        if lock_fd:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                lock_fd.close()
+            except Exception:
+                pass
+
+
+def invalidate_cache():
+    """Mark cache as stale.  Called after any write to MySQL."""
+    try:
+        with open(CACHE_INVALIDATE_PATH, 'w') as f:
+            f.write(str(time.time()))
+    except Exception:
+        pass
+
+
+# ── internal helpers ───────────────────────────────────────────────
+
+def _needs_rebuild():
+    if not os.path.exists(CACHE_DB_PATH):
+        return True
+    try:
+        os.stat(CACHE_INVALIDATE_PATH)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _ensure_cache():
+    """Lightweight gate — at most one stat() per _CHECK_INTERVAL_S.
+
+    NEVER blocks on a rebuild during a request.  If the cache doesn't
+    exist or is stale, kicks off an async rebuild and returns False so
+    the caller falls back to MySQL.
+    """
+    global _last_check_monotonic
+    now = time.monotonic()
+    if now - _last_check_monotonic < _CHECK_INTERVAL_S:
+        if os.path.exists(CACHE_DB_PATH):
+            return True
+    with _check_lock:
+        # Double-check after acquiring lock
+        if now - _last_check_monotonic < _CHECK_INTERVAL_S:
+            if os.path.exists(CACHE_DB_PATH):
+                return True
+        _last_check_monotonic = now
+        if _needs_rebuild():
+            # Kick off async rebuild — don't block the request
+            t = threading.Thread(target=rebuild_cache, daemon=True)
+            t.start()
+            return os.path.exists(CACHE_DB_PATH)
+    return os.path.exists(CACHE_DB_PATH)
+
+
+def _get_conn():
+    """Read-only connection to the cache file."""
+    return sqlite3.connect(
+        f'file:{CACHE_DB_PATH}?mode=ro&immutable=1',
+        uri=True,
+        timeout=1,
+    )
+
+
+def _rows_to_dicts(cursor):
+    cols = [d[0] for d in cursor.description]
+    return [dict(zip(cols, row)) for row in cursor.fetchall()]
+
+
+# ── public read API ────────────────────────────────────────────────
+
+def cache_get_by_internal_filename(internal_filename):
+    """Equivalent to ImageDb.get_image_record_by_internal_filename.
+    Returns list of dicts, or None on any failure (caller falls back to MySQL).
+    """
+    try:
+        if not _ensure_cache():
+            return None
+        conn = _get_conn()
+        try:
+            cur = conn.execute(
+                'SELECT * FROM images WHERE internal_filename = ?',
+                (internal_filename,),
+            )
+            return _rows_to_dicts(cur)
+        finally:
+            conn.close()
+    except Exception as e:
+        logging.warning(f"IMAGE_CACHE miss internal_filename={internal_filename}: {e}")
+        return None
+
+
+def cache_warm():
+    """Pre-build the cache (call before starting workers).
+
+    Usage from container:
+        python -c 'from image_cache import cache_warm; cache_warm()'
+    """
+    logging.basicConfig(level=logging.INFO)
+    rebuild_cache()
+
+
+def cache_get_by_pattern(pattern, column, exact, collection):
+    """Equivalent to ImageDb.get_image_record_by_pattern.
+    Handles both exact and LIKE queries.
+    Returns list of dicts, or None on any failure.
+    """
+    allowed = {'original_filename', 'original_path', 'orig_md5'}
+    if column not in allowed:
+        return None
+
+    try:
+        if not _ensure_cache():
+            return None
+        conn = _get_conn()
+        try:
+            if exact:
+                sql = f'SELECT * FROM images WHERE {column} = ?'
+                params = [pattern]
+            else:
+                sql = f'SELECT * FROM images WHERE {column} LIKE ?'
+                params = [f'%{pattern}%']
+
+            if collection is not None:
+                sql += ' AND collection = ?'
+                params.append(collection)
+
+            cur = conn.execute(sql, params)
+            return _rows_to_dicts(cur)
+        finally:
+            conn.close()
+    except Exception as e:
+        logging.warning(f"IMAGE_CACHE miss {column}={pattern}: {e}")
+        return None

--- a/image_db.py
+++ b/image_db.py
@@ -52,22 +52,25 @@ class ImageDb():
     @contextmanager
     def _get_connection(self):
         """Context manager for pooled connections."""
-        cnx = _get_pool().get_connection()
+        cnx = None
         try:
+            cnx = _get_pool().get_connection()
             yield cnx
         finally:
-            cnx.close()  # Returns connection to pool
+            if cnx:
+                cnx.close()
 
     @contextmanager
     def get_connection(self):
         """Context manager for pooled connections with cursor."""
-        cnx = _get_pool().get_connection()
-        cursor = cnx.cursor(buffered=True)
+        cnx = None
         try:
+            cnx = _get_pool().get_connection()
+            cursor = cnx.cursor(buffered=True)
             yield cnx, cursor
         finally:
-            cursor.close()
-            cnx.close()  # Returns to pool
+            if cnx:
+                cnx.close()
 
     @retry(retry_on_exception=lambda e: isinstance(e, mysql.connector.OperationalError), stop_max_attempt_number=3,
            wait_exponential_multiplier=2)

--- a/image_db.py
+++ b/image_db.py
@@ -27,7 +27,7 @@ def _get_pool():
             return _pool
         pool_config = {
             'pool_name': 'image_db_pool',
-            'pool_size': 10,
+            'pool_size': 32,
             'pool_reset_session': True,
             'user': settings.SQL_USER,
             'password': settings.SQL_PASSWORD,

--- a/image_db.py
+++ b/image_db.py
@@ -3,6 +3,7 @@ from mysql.connector import errorcode
 from mysql.connector.pooling import MySQLConnectionPool
 from retrying import retry
 from contextlib import contextmanager
+import threading
 
 import settings
 from datetime import datetime
@@ -13,12 +14,17 @@ TIME_FORMAT = TIME_FORMAT_NO_OFFSET + "%z"
 
 # Module-level connection pool (singleton)
 _pool = None
+_pool_lock = threading.Lock()
 
 
 def _get_pool():
-    """Get or create the connection pool (singleton)."""
+    """Get or create the connection pool (singleton). Thread-safe."""
     global _pool
-    if _pool is None:
+    if _pool is not None:
+        return _pool
+    with _pool_lock:
+        if _pool is not None:
+            return _pool
         pool_config = {
             'pool_name': 'image_db_pool',
             'pool_size': 10,

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -51,10 +51,32 @@ class S3Connection:
         self._s3 = None
         self._s3_lock = threading.Lock()
         self._s3_created_at = 0
-        self._S3_CLIENT_MAX_AGE = 300  # seconds — recreate client to flush stale pooled connections
+        self._S3_CLIENT_MAX_AGE = 120  # seconds — recreate before MinIO closes idle connections
         atexit.register(self.cleanup_temp_folder)
         weakref.finalize(self, self.cleanup_temp_folder)
 
+
+    @staticmethod
+    def _close_s3_client(client):
+        """Close the underlying urllib3 connection pools to prevent CLOSE-WAIT socket leaks.
+
+        PoolManager.clear() only drops pool references without closing sockets.
+        We must call close() on each connection pool to actually shut down the
+        TCP connections, otherwise they linger in CLOSE-WAIT indefinitely.
+        """
+        try:
+            http_session = client._endpoint.http_session
+            manager = http_session._manager
+            with manager.pools.lock:
+                pools = list(manager.pools._container.values())
+            for pool in pools:
+                try:
+                    pool.close()
+                except Exception:
+                    pass
+            http_session.close()
+        except Exception as e:
+            logging.debug(f"S3 client close error (non-fatal): {e}")
 
     @staticmethod
     def not_found_client_error(e: ClientError) -> bool:
@@ -194,55 +216,63 @@ class S3Connection:
         return p.lstrip('/')
 
 
-    @retry_s3_call()
+    def _create_s3_client(self):
+        """Create a new boto3 S3 client (no I/O, no locks)."""
+        session = boto3.session.Session()
+        return session.client(
+            's3',
+            endpoint_url=self.S3_ENDPOINT,
+            aws_access_key_id=self.S3_ACCESS_KEY,
+            aws_secret_access_key=self.S3_SECRET_KEY,
+            region_name=self.S3_REGION,
+            config=Config(
+                max_pool_connections=4,
+                retries={'max_attempts': 2, 'mode': 'standard'},
+                connect_timeout=3,
+                read_timeout=10,
+                tcp_keepalive=True,
+                signature_version='s3v4',
+                s3={'use_dualstack_endpoint': True}
+            )
+        )
+
     def get_s3(self):
-        """Lazy-initialized S3 client with periodic refresh to flush stale connections."""
+        """Lazy-initialized S3 client with periodic refresh to flush stale connections.
+
+        Recycling prevents CLOSE-WAIT socket leaks: MinIO closes idle connections
+        (sends FIN), but urllib3 never reads the TLS close_notify. Sockets accumulate
+        in CLOSE-WAIT and hang when reused. We recycle the client (and properly close
+        the old sockets) before they go stale.
+
+        IMPORTANT: The lock only protects the pointer swap. All I/O (client creation,
+        bucket validation, old client cleanup) happens outside the lock to prevent
+        thread starvation — if head_bucket or close hangs, only one thread is affected.
+        """
         if not self.S3_ENDPOINT:
             raise RuntimeError("S3 is not enabled")
         now = time.monotonic()
         if self._s3 is not None and (now - self._s3_created_at) < self._S3_CLIENT_MAX_AGE:
             return self._s3
+
+        # Create new client OUTSIDE the lock (no I/O in constructor)
+        client = self._create_s3_client()
+        old_client = None
+
         with self._s3_lock:
-            if self._s3 is not None and (now - self._s3_created_at) < self._S3_CLIENT_MAX_AGE:
+            # Double-check — another thread may have already recycled
+            if self._s3 is not None and (time.monotonic() - self._s3_created_at) < self._S3_CLIENT_MAX_AGE:
+                # Another thread won the race; discard our new client
+                self._close_s3_client(client)
                 return self._s3
-            if self._s3 is not None:
-                logging.info(f"Recycling S3 client (age {round(now - self._s3_created_at)}s)")
-            session = boto3.session.Session()
-            client = session.client(
-                's3',
-                endpoint_url=self.S3_ENDPOINT,
-                aws_access_key_id=self.S3_ACCESS_KEY,
-                aws_secret_access_key=self.S3_SECRET_KEY,
-                region_name=self.S3_REGION,
-                config=Config(
-                    max_pool_connections=4,
-                    retries={'max_attempts': 2, 'mode': 'standard'},
-                    connect_timeout=3,
-                    read_timeout=10,
-                    tcp_keepalive=True,
-                    signature_version='s3v4',
-                    s3={'use_dualstack_endpoint': True}
-                )
-            )
-            # Ensure bucket exists
-            try:
-                client.head_bucket(Bucket=self.S3_BUCKET)
-            except ClientError as e:
-                code = e.response['Error']['Code']
-                if code in ('404', 'NoSuchBucket'):
-                    try:
-                        client.create_bucket(Bucket=self.S3_BUCKET)
-                        time.sleep(10)
-                        client.head_bucket(Bucket=self.S3_BUCKET)
-                    except ClientError as e:
-                        logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
-                        raise
-                else:
-                    logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
-                    raise
+            old_client = self._s3
             self._s3 = client
             self._s3_created_at = time.monotonic()
-        return self._s3
+
+        # All I/O happens OUTSIDE the lock
+        if old_client is not None:
+            self._close_s3_client(old_client)
+            logging.info(f"S3 client recycled (pid={os.getpid()})")
+        return client
 
     def s3_full_key(self, rel: str) -> str:
         """uses posixpath to create full key to avoid double slashes"""
@@ -258,12 +288,22 @@ class S3Connection:
         """
         full_key = self.s3_full_key(rel)
         if self.S3_ENDPOINT:
+            key = self.s3_key(full_key)
+            tid = threading.get_ident()
+            t0 = time.monotonic()
             try:
-                self.get_s3().head_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
+                self.get_s3().head_object(Bucket=self.S3_BUCKET, Key=key)
+                dt = round((time.monotonic() - t0) * 1000, 1)
+                if dt > 500:
+                    logging.warning(f"S3_SLOW head_object SLOW tid={tid} key={key} dt={dt}ms")
                 return True
             except ClientError as e:
+                dt = round((time.monotonic() - t0) * 1000, 1)
                 if e.response['Error']['Code'] == '404':
+                    if dt > 500:
+                        logging.warning(f"S3_SLOW head_object 404 SLOW tid={tid} key={key} dt={dt}ms")
                     return False
+                logging.error(f"S3_ERR head_object tid={tid} key={key} dt={dt}ms error={e}")
                 raise
 
         return False

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -49,6 +49,7 @@ class S3Connection:
 
         self.chunk_size = 64 * 1024
         self._s3 = None
+        self._s3_lock = threading.Lock()
         atexit.register(self.cleanup_temp_folder)
         weakref.finalize(self, self.cleanup_temp_folder)
 
@@ -73,9 +74,10 @@ class S3Connection:
         )
 
     @staticmethod
-    def retry_s3_call():
+    def retry_s3_call(max_retries=5):
         """
-        Retry decorator for S3 operations with progressive backoff and infinite retries after 60s.
+        Retry decorator for S3 operations with progressive backoff.
+        Gives up after max_retries attempts and returns 503.
         """
 
         def decorator(func):
@@ -93,8 +95,13 @@ class S3Connection:
                             abort(404, msg)
 
                         attempt += 1
+                        if attempt >= max_retries:
+                            logging.error(
+                                f"[{func.__name__}] Failed after {attempt} attempts: {type(e).__name__}: {e}"
+                            )
+                            abort(503, f"S3 temporarily unavailable after {attempt} retries")
                         logging.warning(
-                            f"[{func.__name__}] Attempt {attempt} failed: {type(e).__name__}: {e}. "
+                            f"[{func.__name__}] Attempt {attempt}/{max_retries} failed: {type(e).__name__}: {e}. "
                             f"Retrying in {delay}s..."
                         )
                         time.sleep(delay)
@@ -102,8 +109,13 @@ class S3Connection:
 
                     except (EndpointConnectionError, ConnectionClosedError, ReadTimeoutError) as e:
                         attempt += 1
+                        if attempt >= max_retries:
+                            logging.error(
+                                f"[{func.__name__}] Failed after {attempt} attempts: {type(e).__name__}: {e}"
+                            )
+                            abort(503, f"S3 temporarily unavailable after {attempt} retries")
                         logging.warning(
-                            f"[{func.__name__}] Attempt {attempt} failed: {type(e).__name__}: {e}. "
+                            f"[{func.__name__}] Attempt {attempt}/{max_retries} failed: {type(e).__name__}: {e}. "
                             f"Retrying in {delay}s..."
                         )
                         time.sleep(delay)
@@ -151,12 +163,16 @@ class S3Connection:
 
     @retry_s3_call()
     def get_s3(self):
-        """Lazy-initialized singleton S3 client (only if USE_S3)."""
+        """Lazy-initialized singleton S3 client (only if USE_S3). Thread-safe."""
         if not self.S3_ENDPOINT:
             raise RuntimeError("S3 is not enabled")
-        if not hasattr(self, "_s3") or self._s3 is None:
+        if self._s3 is not None:
+            return self._s3
+        with self._s3_lock:
+            if self._s3 is not None:
+                return self._s3
             session = boto3.session.Session()
-            self._s3 = session.client(
+            client = session.client(
                 's3',
                 endpoint_url=self.S3_ENDPOINT,
                 aws_access_key_id=self.S3_ACCESS_KEY,
@@ -166,28 +182,29 @@ class S3Connection:
                     max_pool_connections=64,
                     retries={'max_attempts': 10, 'mode': 'adaptive'},
                     connect_timeout=3,
-                    read_timeout=600,
+                    read_timeout=30,
                     tcp_keepalive=True,
                     signature_version='s3v4',
-                    s3={'use_dualstack_endpoint': True}  # optional; helpful if you want IPv6
+                    s3={'use_dualstack_endpoint': True}
                 )
             )
             # Ensure bucket exists
             try:
-                self._s3.head_bucket(Bucket=self.S3_BUCKET)
+                client.head_bucket(Bucket=self.S3_BUCKET)
             except ClientError as e:
                 code = e.response['Error']['Code']
                 if code in ('404', 'NoSuchBucket'):
                     try:
-                        self._s3.create_bucket(Bucket=self.S3_BUCKET)
+                        client.create_bucket(Bucket=self.S3_BUCKET)
                         time.sleep(10)
-                        self._s3.head_bucket(Bucket=self.S3_BUCKET)
+                        client.head_bucket(Bucket=self.S3_BUCKET)
                     except ClientError as e:
                         logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
                         raise
                 else:
                     logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
                     raise
+            self._s3 = client
         return self._s3
 
     def s3_full_key(self, rel: str) -> str:

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -76,8 +76,8 @@ class S3Connection:
     @staticmethod
     def retry_s3_call(max_retries=5):
         """
-        Retry decorator for S3 operations with progressive backoff.
-        Gives up after max_retries attempts and returns 503.
+        Retry decorator for S3 client initialization only.
+        Retries with progressive backoff on transient errors.
         """
 
         def decorator(func):
@@ -85,37 +85,43 @@ class S3Connection:
             def wrapper(*args, **kwargs):
                 delay = 0
                 attempt = 0
+                t_op_start = time.monotonic()
                 while True:
+                    t0 = time.monotonic()
                     try:
-                        return func(*args, **kwargs)
+                        result = func(*args, **kwargs)
+                        dt = round((time.monotonic() - t0) * 1000, 1)
+                        if dt > 500:
+                            logging.info(f"S3_OP {func.__name__} ok {dt}ms attempt={attempt+1}")
+                        return result
 
                     except ClientError as e:
-                        if S3Connection.not_found_client_error(e):
-                            msg = e.response.get("Error", {}).get("Message") or "Not Found"
-                            abort(404, msg)
-
+                        dt = round((time.monotonic() - t0) * 1000, 1)
                         attempt += 1
                         if attempt >= max_retries:
+                            total_dt = round((time.monotonic() - t_op_start) * 1000, 1)
                             logging.error(
-                                f"[{func.__name__}] Failed after {attempt} attempts: {type(e).__name__}: {e}"
+                                f"S3_OP {func.__name__} FAILED {total_dt}ms after {attempt} attempts: {type(e).__name__}: {e}"
                             )
-                            abort(503, f"S3 temporarily unavailable after {attempt} retries")
+                            raise
                         logging.warning(
-                            f"[{func.__name__}] Attempt {attempt}/{max_retries} failed: {type(e).__name__}: {e}. "
+                            f"S3_OP {func.__name__} retry {dt}ms attempt={attempt}/{max_retries}: {type(e).__name__}: {e}. "
                             f"Retrying in {delay}s..."
                         )
                         time.sleep(delay)
                         delay = min(delay + 10, 60)
 
                     except (EndpointConnectionError, ConnectionClosedError, ReadTimeoutError) as e:
+                        dt = round((time.monotonic() - t0) * 1000, 1)
                         attempt += 1
                         if attempt >= max_retries:
+                            total_dt = round((time.monotonic() - t_op_start) * 1000, 1)
                             logging.error(
-                                f"[{func.__name__}] Failed after {attempt} attempts: {type(e).__name__}: {e}"
+                                f"S3_OP {func.__name__} FAILED {total_dt}ms after {attempt} attempts: {type(e).__name__}: {e}"
                             )
-                            abort(503, f"S3 temporarily unavailable after {attempt} retries")
+                            raise
                         logging.warning(
-                            f"[{func.__name__}] Attempt {attempt}/{max_retries} failed: {type(e).__name__}: {e}. "
+                            f"S3_OP {func.__name__} retry {dt}ms attempt={attempt}/{max_retries}: {type(e).__name__}: {e}. "
                             f"Retrying in {delay}s..."
                         )
                         time.sleep(delay)
@@ -124,6 +130,31 @@ class S3Connection:
             return wrapper
 
         return decorator
+
+    @staticmethod
+    def s3_error_handler(func):
+        """
+        Decorator that converts S3 exceptions to HTTP errors.
+        No retries — fail fast so the client can retry naturally.
+        """
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            t0 = time.monotonic()
+            try:
+                return func(*args, **kwargs)
+            except ClientError as e:
+                dt = round((time.monotonic() - t0) * 1000, 1)
+                if S3Connection.not_found_client_error(e):
+                    logging.debug(f"S3_OP {func.__name__} 404 {dt}ms")
+                    msg = e.response.get("Error", {}).get("Message") or "Not Found"
+                    abort(404, msg)
+                logging.error(f"S3_OP {func.__name__} FAILED {dt}ms: {type(e).__name__}: {e}")
+                abort(503, "S3 temporarily unavailable")
+            except (EndpointConnectionError, ConnectionClosedError, ReadTimeoutError) as e:
+                dt = round((time.monotonic() - t0) * 1000, 1)
+                logging.error(f"S3_OP {func.__name__} FAILED {dt}ms: {type(e).__name__}: {e}")
+                abort(503, "S3 temporarily unavailable")
+        return wrapper
 
     def cleanup_temp_folder(self):
         """Remove this instance's TMP_FOLDER and stale s3_temp folders safely."""
@@ -180,9 +211,9 @@ class S3Connection:
                 region_name=self.S3_REGION,
                 config=Config(
                     max_pool_connections=64,
-                    retries={'max_attempts': 10, 'mode': 'adaptive'},
+                    retries={'max_attempts': 2, 'mode': 'standard'},
                     connect_timeout=3,
-                    read_timeout=30,
+                    read_timeout=10,
                     tcp_keepalive=True,
                     signature_version='s3v4',
                     s3={'use_dualstack_endpoint': True}
@@ -213,7 +244,7 @@ class S3Connection:
         prefix = (self.S3_PREFIX or "").strip("/")
         return posixpath.join(prefix, rel) if prefix else rel
 
-    @retry_s3_call()
+    @s3_error_handler
     def storage_exists(self, rel: str) -> bool:
         """
         Check if object exists locally or in S3.
@@ -231,7 +262,7 @@ class S3Connection:
 
         return False
 
-    @retry_s3_call()
+    @s3_error_handler
     def orig_location(self, rel: str) -> str:
         """
         Validate that the original exists (S3 mode) before returning rel key/path.
@@ -240,7 +271,7 @@ class S3Connection:
             abort(404, f"Missing object: {rel}")
         return rel
 
-    @retry_s3_call()
+    @s3_error_handler
     @contextmanager
     def storage_tempfile(self, rel: str):
         """
@@ -252,12 +283,15 @@ class S3Connection:
         fd, tmp_path = tempfile.mkstemp(dir=self.TMP_FOLDER, prefix="s3dl_", suffix=ext or "")
         os.close(fd)
         try:
+            t0 = time.monotonic()
             self.get_s3().download_file(self.S3_BUCKET, self.s3_key(full_key), tmp_path)
+            dt = round((time.monotonic() - t0) * 1000, 1)
+            file_size = os.path.getsize(tmp_path)
+            logging.info(f"S3_DOWNLOAD key={self.s3_key(full_key)} size={file_size} bytes dt={dt}ms")
             yield tmp_path
         finally:
             self.remove_tempfile(tmp_path)
 
-    @retry_s3_call()
     def remove_tempfile(self, tmp_path: str):
         """
         removes temp-files created by the storage download with exception
@@ -269,7 +303,7 @@ class S3Connection:
             except OSError as e:
                 logging.warning(f"Could not delete {tmp_path}: {e}")
 
-    @retry_s3_call()
+    @s3_error_handler
     def storage_download(self, rel: str) -> str:
         """
         downloads from S3 to a temp file and returns the local path.
@@ -288,7 +322,7 @@ class S3Connection:
             self.remove_tempfile(tmp_path)
             raise
 
-    @retry_s3_call()
+    @s3_error_handler
     def storage_save(self, rel: str, file_object):
         """
         Save file data either to local filesystem or S3.
@@ -302,7 +336,7 @@ class S3Connection:
             kwargs["ContentType"] = mime
         self.get_s3().put_object(**kwargs)
 
-    @retry_s3_call()
+    @s3_error_handler
     def storage_delete(self, rel: str):
         """
         Delete the object referenced by rel from local filesystem or S3.
@@ -314,7 +348,7 @@ class S3Connection:
             return
         abort(404)
 
-    @retry_s3_call()
+    @s3_error_handler
     def storage_url(self, rel: str):
         """
         Generate a pre-signed URL for an S3 object if running in S3 mode. Returns None otherwise
@@ -328,7 +362,6 @@ class S3Connection:
             )
         return None
 
-    @retry_s3_call()
     def stream(self, body):
         """loads the stream by iterating through the file body by chunk size"""
         try:
@@ -337,7 +370,7 @@ class S3Connection:
         finally:
             body.close()
 
-    @retry_s3_call()
+    @s3_error_handler
     def s3_stream_response(self, rel, downloadname=None, filename_for_ct=None):
         """Return a Bottle response for an S3 object.
 

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -2,6 +2,7 @@
 Variables for s3 api set in docker-compose.yml as environment variables"""
 import os
 import shutil
+import signal
 import sys
 import tempfile
 import uuid
@@ -23,6 +24,40 @@ import threading
 import atexit
 import weakref
 import posixpath
+
+
+class S3CallTimeout(Exception):
+    """Raised when an S3 operation exceeds its hard SIGALRM timeout.
+
+    boto3's read_timeout is per-recv(), so trickle data from a stalled MinIO
+    can keep the socket alive indefinitely.  SIGALRM is the only mechanism
+    that can interrupt a blocking SSL read from the outside.
+    Requires threads=1 in uWSGI (signal delivery targets the main thread).
+    """
+
+
+@contextmanager
+def s3_call_timeout(seconds):
+    """Hard per-call timeout using SIGALRM.
+
+    Only arms the alarm when running in the main thread (threads=1 uWSGI).
+    Falls back to a no-op in non-main threads so the code is safe to run
+    in tests or with threads>1 (where boto3 read_timeout is the only guard).
+    """
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise S3CallTimeout(f"S3 call exceeded {seconds}s hard timeout")
+
+    old_handler = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)
 
 
 class S3Connection:
@@ -166,6 +201,10 @@ class S3Connection:
             t0 = time.monotonic()
             try:
                 return func(*args, **kwargs)
+            except S3CallTimeout as e:
+                dt = round((time.monotonic() - t0) * 1000, 1)
+                logging.error(f"S3_OP {func.__name__} HARD_TIMEOUT {dt}ms: {e}")
+                abort(503, "S3 temporarily unavailable")
             except ClientError as e:
                 dt = round((time.monotonic() - t0) * 1000, 1)
                 if S3Connection.not_found_client_error(e):
@@ -227,12 +266,12 @@ class S3Connection:
             region_name=self.S3_REGION,
             config=Config(
                 max_pool_connections=4,
-                retries={'max_attempts': 2, 'mode': 'standard'},
+                retries={'max_attempts': 1, 'mode': 'standard'},
                 connect_timeout=3,
-                read_timeout=10,
+                read_timeout=5,
                 tcp_keepalive=True,
                 signature_version='s3v4',
-                s3={'use_dualstack_endpoint': True}
+                s3={'use_dualstack_endpoint': False}
             )
         )
 
@@ -292,7 +331,8 @@ class S3Connection:
             tid = threading.get_ident()
             t0 = time.monotonic()
             try:
-                self.get_s3().head_object(Bucket=self.S3_BUCKET, Key=key)
+                with s3_call_timeout(3):
+                    self.get_s3().head_object(Bucket=self.S3_BUCKET, Key=key)
                 dt = round((time.monotonic() - t0) * 1000, 1)
                 if dt > 500:
                     logging.warning(f"S3_SLOW head_object SLOW tid={tid} key={key} dt={dt}ms")
@@ -330,7 +370,8 @@ class S3Connection:
         os.close(fd)
         try:
             t0 = time.monotonic()
-            self.get_s3().download_file(self.S3_BUCKET, self.s3_key(full_key), tmp_path)
+            with s3_call_timeout(8):
+                self.get_s3().download_file(self.S3_BUCKET, self.s3_key(full_key), tmp_path)
             dt = round((time.monotonic() - t0) * 1000, 1)
             file_size = os.path.getsize(tmp_path)
             logging.info(f"S3_DOWNLOAD key={self.s3_key(full_key)} size={file_size} bytes dt={dt}ms")
@@ -362,7 +403,8 @@ class S3Connection:
         os.close(fd)
 
         try:
-            self.get_s3().download_file(self.S3_BUCKET, self.s3_key(full_key), tmp_path)
+            with s3_call_timeout(8):
+                self.get_s3().download_file(self.S3_BUCKET, self.s3_key(full_key), tmp_path)
             return tmp_path
         except Exception:
             self.remove_tempfile(tmp_path)
@@ -380,7 +422,8 @@ class S3Connection:
         kwargs = dict(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key), Body=file_object.read())
         if mime:
             kwargs["ContentType"] = mime
-        self.get_s3().put_object(**kwargs)
+        with s3_call_timeout(8):
+            self.get_s3().put_object(**kwargs)
 
     @s3_error_handler
     def storage_delete(self, rel: str):
@@ -390,7 +433,8 @@ class S3Connection:
         full_key = self.s3_full_key(rel)
 
         if self.S3_ENDPOINT:
-            self.get_s3().delete_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
+            with s3_call_timeout(3):
+                self.get_s3().delete_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
             return
         abort(404)
 
@@ -447,8 +491,10 @@ class S3Connection:
 
         # --- Slow path: stream through Python (original behavior) ---
         s3 = self.get_s3()
-        head = s3.head_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
-        obj = s3.get_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
+        with s3_call_timeout(3):
+            head = s3.head_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
+        with s3_call_timeout(3):
+            obj = s3.get_object(Bucket=self.S3_BUCKET, Key=self.s3_key(full_key))
         body = obj["Body"]  # botocore.response.StreamingBody
 
         mime, _ = guess_type(filename_for_ct or full_key)

--- a/s3_server_utils.py
+++ b/s3_server_utils.py
@@ -50,6 +50,8 @@ class S3Connection:
         self.chunk_size = 64 * 1024
         self._s3 = None
         self._s3_lock = threading.Lock()
+        self._s3_created_at = 0
+        self._S3_CLIENT_MAX_AGE = 300  # seconds — recreate client to flush stale pooled connections
         atexit.register(self.cleanup_temp_folder)
         weakref.finalize(self, self.cleanup_temp_folder)
 
@@ -194,14 +196,17 @@ class S3Connection:
 
     @retry_s3_call()
     def get_s3(self):
-        """Lazy-initialized singleton S3 client (only if USE_S3). Thread-safe."""
+        """Lazy-initialized S3 client with periodic refresh to flush stale connections."""
         if not self.S3_ENDPOINT:
             raise RuntimeError("S3 is not enabled")
-        if self._s3 is not None:
+        now = time.monotonic()
+        if self._s3 is not None and (now - self._s3_created_at) < self._S3_CLIENT_MAX_AGE:
             return self._s3
         with self._s3_lock:
-            if self._s3 is not None:
+            if self._s3 is not None and (now - self._s3_created_at) < self._S3_CLIENT_MAX_AGE:
                 return self._s3
+            if self._s3 is not None:
+                logging.info(f"Recycling S3 client (age {round(now - self._s3_created_at)}s)")
             session = boto3.session.Session()
             client = session.client(
                 's3',
@@ -210,7 +215,7 @@ class S3Connection:
                 aws_secret_access_key=self.S3_SECRET_KEY,
                 region_name=self.S3_REGION,
                 config=Config(
-                    max_pool_connections=64,
+                    max_pool_connections=4,
                     retries={'max_attempts': 2, 'mode': 'standard'},
                     connect_timeout=3,
                     read_timeout=10,
@@ -236,6 +241,7 @@ class S3Connection:
                     logging.critical(f"Bucket {self.S3_BUCKET} does not exist and could not be created.", e)
                     raise
             self._s3 = client
+            self._s3_created_at = time.monotonic()
         return self._s3
 
     def s3_full_key(self, rel: str) -> str:

--- a/server.py
+++ b/server.py
@@ -27,7 +27,7 @@ from bottle import Bottle
 from image_db import ImageDb
 from image_db import TIME_FORMAT
 from urllib.parse import unquote
-from s3_server_utils import S3Connection
+from s3_server_utils import S3Connection, s3_call_timeout, S3CallTimeout
 
 # Phase 6: crash forensics — dump Python tracebacks on SIGSEGV/SIGABRT
 faulthandler.enable(file=sys.stderr, all_threads=True)
@@ -37,6 +37,34 @@ except (OSError, AttributeError):
     pass  # SIGUSR1 not available on all platforms
 
 app = application = Bottle()
+
+
+class DbCallTimeout(Exception):
+    """Raised when a database operation exceeds its hard SIGALRM timeout."""
+
+
+@contextmanager
+def db_call_timeout(seconds):
+    """Hard per-call timeout for DB operations using SIGALRM.
+
+    Same mechanism as s3_call_timeout — only arms in main thread (threads=1).
+    Prevents MySQL queries from hanging until harakiri when the DB is slow
+    (NFS contention, lock waits, network stalls).
+    """
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise DbCallTimeout(f"DB call exceeded {seconds}s hard timeout")
+
+    old_handler = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)
 
 # initializing s3 connection
 s3_conn = S3Connection()
@@ -395,7 +423,12 @@ def static(path):
         abort(404)
     filename = path.split('/')[-1]
     image_db = get_image_db()
-    records = image_db.get_image_record_by_internal_filename(filename)
+    try:
+        with db_call_timeout(5):
+            records = image_db.get_image_record_by_internal_filename(filename)
+    except DbCallTimeout:
+        logging.error(f"DB_TIMEOUT static filename={filename}")
+        abort(503, "Database temporarily unavailable")
     if len(records) < 1:
         log(f"Static record not found: {request.query.filename}")
         response.content_type = 'text/plain; charset=utf-8'
@@ -464,8 +497,13 @@ def fileget():
     """Returns the file data of the file indicated by the query parameters."""
     log(f"fileget {request.query.filename}")
     image_db = get_image_db()
-    with trace_stage('db_lookup'):
-        records = image_db.get_image_record_by_internal_filename(request.query.filename)
+    try:
+        with trace_stage('db_lookup'):
+            with db_call_timeout(5):
+                records = image_db.get_image_record_by_internal_filename(request.query.filename)
+    except DbCallTimeout:
+        logging.error(f"DB_TIMEOUT fileget db_lookup filename={request.query.filename}")
+        abort(503, "Database temporarily unavailable")
     log("Fileget complete")
     if len(records) < 1:
         log(f"Record not found: {request.query.filename}")
@@ -548,14 +586,19 @@ def fileupload():
         return 'Ignoring thumbnail upload!'
 
     # Check for duplicates by original_path in DB
-    if 'original_path' in request.forms:
-        response_list = image_db.get_image_record_by_original_path(
-            original_path=request.forms['original_path'],
-            collection=request.forms.coll,
-            exact=True
-        )
-    else:
-        response_list = []
+    try:
+        with db_call_timeout(5):
+            if 'original_path' in request.forms:
+                response_list = image_db.get_image_record_by_original_path(
+                    original_path=request.forms['original_path'],
+                    collection=request.forms.coll,
+                    exact=True
+                )
+            else:
+                response_list = []
+    except DbCallTimeout:
+        logging.error(f"DB_TIMEOUT fileupload duplicate_check")
+        abort(503, "Database temporarily unavailable")
 
     upload = list(request.files.values())[0]
     log(f"Saving upload: {upload}")
@@ -709,7 +752,12 @@ def get_image_record():
     if not search_function:
         abort(400, 'Invalid search type')
 
-    record_list = search_function()
+    try:
+        with db_call_timeout(5):
+            record_list = search_function()
+    except DbCallTimeout:
+        logging.error(f"DB_TIMEOUT getImageRecord search_type={search_type} query={query_string}")
+        abort(503, "Database temporarily unavailable")
     log(f"Record list: {record_list}")
 
     if not record_list:

--- a/server.py
+++ b/server.py
@@ -1,9 +1,15 @@
 import logging
 import os
 import shutil
+import signal
 import sys
+import faulthandler
 import time
 import tempfile
+import threading
+import uuid
+import resource
+from contextlib import contextmanager
 from functools import wraps
 from glob import glob
 from mimetypes import guess_type
@@ -23,6 +29,13 @@ from image_db import TIME_FORMAT
 from urllib.parse import unquote
 from s3_server_utils import S3Connection
 
+# Phase 6: crash forensics — dump Python tracebacks on SIGSEGV/SIGABRT
+faulthandler.enable(file=sys.stderr, all_threads=True)
+try:
+    faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True)
+except (OSError, AttributeError):
+    pass  # SIGUSR1 not available on all platforms
+
 app = application = Bottle()
 
 # initializing s3 connection
@@ -40,6 +53,8 @@ from bottle import (
 
 BaseRequest.MEMFILE_MAX = 300 * 1024 * 1024
 
+_server_start_time = time.monotonic()
+
 # Singleton ImageDb instance - pool handles connections
 _image_db = None
 
@@ -48,6 +63,61 @@ def get_image_db():
     if _image_db is None:
         _image_db = ImageDb()
     return _image_db
+
+
+class RequestTracer:
+    """Bottle plugin: wraps every request with timing, unique ID, and structured JSON logging."""
+    name = 'request_tracer'
+    api = 2
+
+    def apply(self, callback, route):
+        def wrapper(*args, **kwargs):
+            req_id = request.headers.get('X-Request-Id', str(uuid.uuid4())[:8])
+            request.trace = {
+                'req_id': req_id,
+                'method': request.method,
+                'path': request.path,
+                'query': dict(request.query),
+                't_start': time.monotonic(),
+                'stages': [],
+                'pid': os.getpid(),
+                'tid': threading.get_ident(),
+            }
+            try:
+                result = callback(*args, **kwargs)
+                request.trace['status'] = response.status_code
+                return result
+            except HTTPResponse as e:
+                request.trace['status'] = e.status_code
+                raise
+            except Exception as e:
+                request.trace['status'] = 500
+                request.trace['error'] = f"{type(e).__name__}: {e}"
+                raise
+            finally:
+                request.trace['t_total_ms'] = round(
+                    (time.monotonic() - request.trace['t_start']) * 1000, 1
+                )
+                # Only log non-trivial requests (skip GET / which is noisy)
+                if request.trace.get('t_total_ms', 0) > 100 or request.path != '/':
+                    logging.info("REQ_TRACE " + json.dumps(request.trace, default=str))
+        return wrapper
+
+app.install(RequestTracer())
+
+
+@contextmanager
+def trace_stage(name):
+    """Add a timed stage to the current request trace."""
+    t0 = time.monotonic()
+    try:
+        yield
+    finally:
+        dt = round((time.monotonic() - t0) * 1000, 1)
+        try:
+            request.trace['stages'].append((name, dt))
+        except (AttributeError, KeyError):
+            pass
 
 
 def log(msg):
@@ -213,7 +283,8 @@ def resolve_file(filename, collection, type, scale):
     file_path = os.path.join(relpath, storename)
 
     if not thumb_p:
-        return s3_conn.orig_location(file_path)
+        with trace_stage('orig_location'):
+            return s3_conn.orig_location(file_path)
 
     scale = int(scale)
     mimetype, encoding = guess_type(storename)
@@ -227,9 +298,10 @@ def resolve_file(filename, collection, type, scale):
     rel_thumb = os.path.join(relpath, scaled_name)
 
     if s3_conn.S3_ENDPOINT:
-        if s3_conn.storage_exists(rel_thumb):
-            log("Serving previously scaled thumbnail from S3")
-            return rel_thumb
+        with trace_stage('s3_exists_thumb'):
+            if s3_conn.storage_exists(rel_thumb):
+                log("Serving previously scaled thumbnail from S3")
+                return rel_thumb
     else:
         local_thumb = os.path.join(settings.BASE_DIR, rel_thumb)
         if os.path.exists(local_thumb):
@@ -241,25 +313,40 @@ def resolve_file(filename, collection, type, scale):
     if s3_conn.S3_ENDPOINT:
         orig_key = os.path.join(get_rel_path(collection, False, storename), storename)
 
-        if not s3_conn.storage_exists(orig_key):
-            abort(404, f"Missing object: {orig_key}")
+        with trace_stage('s3_exists_orig'):
+            if not s3_conn.storage_exists(orig_key):
+                abort(404, f"Missing object: {orig_key}")
 
         # Context-managed download ensures the temp file is deleted after use
-        with s3_conn.storage_tempfile(orig_key) as input_path:
-            convert_args = ['-resize', f"{scale}x{scale}>"]
-            convert_input = input_path
-            if mimetype == 'application/pdf':
-                convert_input = f"{input_path}[0]"
-                convert_args.extend(['-background', 'white', '-flatten'])
+        with trace_stage('s3_download'):
+            with s3_conn.storage_tempfile(orig_key) as input_path:
+                try:
+                    request.trace['file_size_bytes'] = os.path.getsize(input_path)
+                except (AttributeError, KeyError):
+                    pass
 
-            tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
-            subprocess.run(["convert", convert_input] + convert_args + [tmp_out], check=True, timeout=120, close_fds=False)
+                convert_args = ['-resize', f"{scale}x{scale}>"]
+                convert_input = input_path
+                if mimetype == 'application/pdf':
+                    convert_input = f"{input_path}[0]"
+                    convert_args.extend(['-background', 'white', '-flatten'])
 
-            try:
-                with open(tmp_out, 'rb') as f:
-                    s3_conn.storage_save(rel_thumb, f)
-            finally:
-                s3_conn.remove_tempfile(tmp_out)
+                tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
+                with trace_stage('imagemagick_convert'):
+                    result = subprocess.run(
+                        ["convert", convert_input] + convert_args + [tmp_out],
+                        check=True, timeout=30, close_fds=False,
+                        capture_output=True
+                    )
+                    if result.stderr:
+                        logging.warning(f"CONVERT_STDERR: {result.stderr.decode('utf-8', errors='replace')[:500]}")
+
+                try:
+                    with trace_stage('s3_upload_thumb'):
+                        with open(tmp_out, 'rb') as f:
+                            s3_conn.storage_save(rel_thumb, f)
+                finally:
+                    s3_conn.remove_tempfile(tmp_out)
 
         return rel_thumb
     else:
@@ -277,7 +364,7 @@ def resolve_file(filename, collection, type, scale):
         convert_args.extend(['-background', 'white', '-flatten'])
 
     tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
-    subprocess.run(["convert", input_path] + convert_args + [tmp_out], check=True, timeout=120, close_fds=False)
+    subprocess.run(["convert", input_path] + convert_args + [tmp_out], check=True, timeout=30, close_fds=False)
 
     final_path = os.path.join(settings.BASE_DIR, rel_thumb)
     # using shutil to account for mounted filesystem
@@ -361,7 +448,8 @@ def fileget():
     """Returns the file data of the file indicated by the query parameters."""
     log(f"fileget {request.query.filename}")
     image_db = get_image_db()
-    records = image_db.get_image_record_by_internal_filename(request.query.filename)
+    with trace_stage('db_lookup'):
+        records = image_db.get_image_record_by_internal_filename(request.query.filename)
     log("Fileget complete")
     if len(records) < 1:
         log(f"Record not found: {request.query.filename}")
@@ -721,6 +809,43 @@ def web_asset_store():
     response.content_type = 'text/xml; charset=utf-8'
     return template('web_asset_store.xml', host="%s:%d" % (settings.SERVER_NAME, settings.SERVER_PORT),
                     protocol=settings.SERVER_PROTOCOL)
+
+
+@app.route('/debug/health')
+def debug_health():
+    """Lightweight health check — does NOT touch S3 or MySQL."""
+    try:
+        import uwsgi
+        worker_info = {
+            'worker_id': uwsgi.worker_id(),
+            'total_requests': uwsgi.total_requests(),
+        }
+    except (ImportError, AttributeError):
+        worker_info = {}
+
+    rusage = resource.getrusage(resource.RUSAGE_SELF)
+    info = {
+        'status': 'ok',
+        'pid': os.getpid(),
+        'tid': threading.get_ident(),
+        'active_threads': threading.active_count(),
+        'rss_kb': rusage.ru_maxrss,
+        'utime_s': round(rusage.ru_utime, 2),
+        'stime_s': round(rusage.ru_stime, 2),
+        'worker': worker_info,
+        'uptime_s': round(time.monotonic() - _server_start_time, 1),
+        's3_temp_dirs': len(os.listdir('s3_temp')) if os.path.isdir('s3_temp') else 0,
+    }
+    response.content_type = 'application/json'
+    return json.dumps(info)
+
+
+@app.route('/debug/pool')
+def debug_pool():
+    """MySQL connection pool stats."""
+    from image_db import _pool_stats
+    response.content_type = 'application/json'
+    return json.dumps(_pool_stats)
 
 
 @app.route('/')

--- a/server.py
+++ b/server.py
@@ -253,7 +253,7 @@ def resolve_file(filename, collection, type, scale):
                 convert_args.extend(['-background', 'white', '-flatten'])
 
             tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
-            subprocess.run(["convert", convert_input] + convert_args + [tmp_out], check=True, timeout=120)
+            subprocess.run(["convert", convert_input] + convert_args + [tmp_out], check=True, timeout=120, close_fds=False)
 
             try:
                 with open(tmp_out, 'rb') as f:
@@ -277,7 +277,7 @@ def resolve_file(filename, collection, type, scale):
         convert_args.extend(['-background', 'white', '-flatten'])
 
     tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
-    subprocess.run(["convert", input_path] + convert_args + [tmp_out], check=True, timeout=120)
+    subprocess.run(["convert", input_path] + convert_args + [tmp_out], check=True, timeout=120, close_fds=False)
 
     final_path = os.path.join(settings.BASE_DIR, rel_thumb)
     # using shutil to account for mounted filesystem

--- a/server.py
+++ b/server.py
@@ -28,6 +28,13 @@ from image_db import ImageDb
 from image_db import TIME_FORMAT
 from urllib.parse import unquote
 from s3_server_utils import S3Connection, s3_call_timeout, S3CallTimeout
+from image_cache import (
+    cache_get_by_internal_filename,
+    cache_get_by_pattern,
+    invalidate_cache,
+    CACHE_DB_PATH,
+    CACHE_INVALIDATE_PATH,
+)
 
 # Phase 6: crash forensics — dump Python tracebacks on SIGSEGV/SIGABRT
 faulthandler.enable(file=sys.stderr, all_threads=True)
@@ -423,12 +430,14 @@ def static(path):
         abort(404)
     filename = path.split('/')[-1]
     image_db = get_image_db()
-    try:
-        with db_call_timeout(5):
-            records = image_db.get_image_record_by_internal_filename(filename)
-    except DbCallTimeout:
-        logging.error(f"DB_TIMEOUT static filename={filename}")
-        abort(503, "Database temporarily unavailable")
+    records = cache_get_by_internal_filename(filename)
+    if records is None:
+        try:
+            with db_call_timeout(5):
+                records = image_db.get_image_record_by_internal_filename(filename)
+        except DbCallTimeout:
+            logging.error(f"DB_TIMEOUT static filename={filename}")
+            abort(503, "Database temporarily unavailable")
     if len(records) < 1:
         log(f"Static record not found: {request.query.filename}")
         response.content_type = 'text/plain; charset=utf-8'
@@ -497,13 +506,15 @@ def fileget():
     """Returns the file data of the file indicated by the query parameters."""
     log(f"fileget {request.query.filename}")
     image_db = get_image_db()
-    try:
-        with trace_stage('db_lookup'):
-            with db_call_timeout(5):
-                records = image_db.get_image_record_by_internal_filename(request.query.filename)
-    except DbCallTimeout:
-        logging.error(f"DB_TIMEOUT fileget db_lookup filename={request.query.filename}")
-        abort(503, "Database temporarily unavailable")
+    with trace_stage('db_lookup'):
+        records = cache_get_by_internal_filename(request.query.filename)
+        if records is None:
+            try:
+                with db_call_timeout(5):
+                    records = image_db.get_image_record_by_internal_filename(request.query.filename)
+            except DbCallTimeout:
+                logging.error(f"DB_TIMEOUT fileget db_lookup filename={request.query.filename}")
+                abort(503, "Database temporarily unavailable")
     log("Fileget complete")
     if len(records) < 1:
         log(f"Record not found: {request.query.filename}")
@@ -677,6 +688,7 @@ def fileupload():
         print(f"Unexpected error: {ex}")
         abort(500, f'Unexpected error: {ex}')
 
+    invalidate_cache()
     log(f"Image upload complete: original filename {original_filename} mapped to {storename}")
     end_save = time.time()
     log(f"Total time: {end_save - start_save}")
@@ -719,6 +731,7 @@ def filedelete():
 
     response.content_type = 'text/plain; charset=utf-8'
     image_db.delete_image_record(storename)
+    invalidate_cache()
     return 'Ok.'
 
 
@@ -741,23 +754,32 @@ def get_image_record():
     exact = str2bool(query_params.get('exact', default='False'))
     collection = query_params.get('coll')
 
-    search_functions = {
-        'filename': lambda: image_db.get_image_record_by_original_filename(query_string, exact=exact,
-                                                                           collection=collection),
-        'path': lambda: image_db.get_image_record_by_original_path(query_string, exact=exact, collection=collection),
-        'md5': lambda: image_db.get_image_record_by_original_image_md5(query_string, collection=collection)
+    cache_columns = {
+        'filename': 'original_filename',
+        'path': 'original_path',
+        'md5': 'orig_md5',
     }
-
-    search_function = search_functions.get(search_type)
-    if not search_function:
+    cache_col = cache_columns.get(search_type)
+    if not cache_col:
         abort(400, 'Invalid search type')
 
-    try:
-        with db_call_timeout(5):
-            record_list = search_function()
-    except DbCallTimeout:
-        logging.error(f"DB_TIMEOUT getImageRecord search_type={search_type} query={query_string}")
-        abort(503, "Database temporarily unavailable")
+    # md5 search is always exact
+    cache_exact = exact if search_type != 'md5' else True
+    record_list = cache_get_by_pattern(query_string, cache_col, cache_exact, collection)
+
+    if record_list is None:
+        search_functions = {
+            'filename': lambda: image_db.get_image_record_by_original_filename(query_string, exact=exact,
+                                                                               collection=collection),
+            'path': lambda: image_db.get_image_record_by_original_path(query_string, exact=exact, collection=collection),
+            'md5': lambda: image_db.get_image_record_by_original_image_md5(query_string, collection=collection)
+        }
+        try:
+            with db_call_timeout(5):
+                record_list = search_functions[search_type]()
+        except DbCallTimeout:
+            logging.error(f"DB_TIMEOUT getImageRecord search_type={search_type} query={query_string}")
+            abort(503, "Database temporarily unavailable")
     log(f"Record list: {record_list}")
 
     if not record_list:
@@ -888,6 +910,15 @@ def debug_health():
         worker_info = {}
 
     rusage = resource.getrusage(resource.RUSAGE_SELF)
+    cache_info = {}
+    try:
+        cache_stat = os.stat(CACHE_DB_PATH)
+        cache_info['size_mb'] = round(cache_stat.st_size / 1048576, 1)
+        cache_info['age_s'] = round(time.time() - cache_stat.st_mtime, 1)
+        cache_info['stale'] = os.path.exists(CACHE_INVALIDATE_PATH)
+    except FileNotFoundError:
+        cache_info['exists'] = False
+
     info = {
         'status': 'ok',
         'pid': os.getpid(),
@@ -899,6 +930,7 @@ def debug_health():
         'worker': worker_info,
         'uptime_s': round(time.monotonic() - _server_start_time, 1),
         's3_temp_dirs': len(os.listdir('s3_temp')) if os.path.isdir('s3_temp') else 0,
+        'image_cache': cache_info,
     }
     response.content_type = 'application/json'
     return json.dumps(info)

--- a/server.py
+++ b/server.py
@@ -271,12 +271,24 @@ def allow_cross_origin(func):
     return wrapper
 
 
+def _check_deadline(deadline):
+    """Abort with 503 if the request deadline has passed."""
+    if time.monotonic() > deadline:
+        logging.warning("REQUEST_DEADLINE exceeded, aborting before harakiri")
+        abort(503, "Request timeout")
+
+
+# Budget must be well under harakiri (20s) so we abort cleanly
+_RESOLVE_DEADLINE_S = 15
+
+
 def resolve_file(filename, collection, type, scale):
     """Inspect the request object to determine the file being requested.
     If the request is for a thumbnail , and it has not been generated, do
     so before returning accession_copy.
     Returns the relative path to the requested file in the base attachments directory.
     """
+    deadline = time.monotonic() + _RESOLVE_DEADLINE_S
     thumb_p = (type == "T")
     storename = filename
     relpath = get_rel_path(collection, thumb_p, storename)
@@ -313,10 +325,12 @@ def resolve_file(filename, collection, type, scale):
     if s3_conn.S3_ENDPOINT:
         orig_key = os.path.join(get_rel_path(collection, False, storename), storename)
 
+        _check_deadline(deadline)
         with trace_stage('s3_exists_orig'):
             if not s3_conn.storage_exists(orig_key):
                 abort(404, f"Missing object: {orig_key}")
 
+        _check_deadline(deadline)
         # Context-managed download ensures the temp file is deleted after use
         with trace_stage('s3_download'):
             with s3_conn.storage_tempfile(orig_key) as input_path:
@@ -325,6 +339,7 @@ def resolve_file(filename, collection, type, scale):
                 except (AttributeError, KeyError):
                     pass
 
+                _check_deadline(deadline)
                 convert_args = ['-resize', f"{scale}x{scale}>"]
                 convert_input = input_path
                 if mimetype == 'application/pdf':
@@ -341,6 +356,7 @@ def resolve_file(filename, collection, type, scale):
                     if result.stderr:
                         logging.warning(f"CONVERT_STDERR: {result.stderr.decode('utf-8', errors='replace')[:500]}")
 
+                _check_deadline(deadline)
                 try:
                     with trace_stage('s3_upload_thumb'):
                         with open(tmp_out, 'rb') as f:

--- a/server.py
+++ b/server.py
@@ -16,7 +16,7 @@ from collection_definitions import COLLECTION_DIRS
 from datetime import datetime
 from time import sleep
 from cas_metadata_tools import MetadataTools
-from sh import convert
+import subprocess
 from bottle import Bottle
 from image_db import ImageDb
 from image_db import TIME_FORMAT
@@ -253,7 +253,7 @@ def resolve_file(filename, collection, type, scale):
                 convert_args.extend(['-background', 'white', '-flatten'])
 
             tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
-            convert(convert_input, *convert_args, tmp_out)
+            subprocess.run(["convert", convert_input] + convert_args + [tmp_out], check=True, timeout=120)
 
             try:
                 with open(tmp_out, 'rb') as f:
@@ -277,7 +277,7 @@ def resolve_file(filename, collection, type, scale):
         convert_args.extend(['-background', 'white', '-flatten'])
 
     tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=ext).name
-    convert(input_path, *convert_args, tmp_out)
+    subprocess.run(["convert", input_path] + convert_args + [tmp_out], check=True, timeout=120)
 
     final_path = os.path.join(settings.BASE_DIR, rel_thumb)
     # using shutil to account for mounted filesystem

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -32,7 +32,7 @@ max-worker-lifetime = 3600
 max-worker-lifetime-delta = 3600
 worker-reload-mercy = 30
 reload-mercy = 30
-harakiri = 300
+harakiri = 60
 harakiri-verbose = true
 
 ; --- I/O robustness ---

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -36,8 +36,8 @@ harakiri = 300
 harakiri-verbose = true
 
 ; --- I/O robustness ---
-socket-timeout = 600
-http-timeout   = 600
+socket-timeout = 120
+http-timeout   = 120
 buffer-size    = 65535
 ignore-sigpipe = true
 ignore-write-errors = true

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -17,14 +17,16 @@ socket = 0.0.0.0:29000
 so-keepalive = true
 tcp-keepalive = 2
 
-; Pool size
-processes = 16
-threads = 8
+; Pool size — threads=1 prevents GIL contention cascade when S3 calls hang.
+; With threads>1, one hung SSL read holds the GIL and blocks all threads in
+; the process (including /debug/health).  threads=1 isolates each worker.
+processes = 32
+threads = 1
 
 ; cheaper algo
 cheaper-algo = spare
-cheaper = 8
-cheaper-initial = 16
+cheaper = 16
+cheaper-initial = 32
 cheaper-step = 2
 
 ; Worker expiry settings
@@ -32,7 +34,7 @@ max-worker-lifetime = 3600
 max-worker-lifetime-delta = 3600
 worker-reload-mercy = 30
 reload-mercy = 30
-harakiri = 60
+harakiri = 20
 harakiri-verbose = true
 
 ; --- I/O robustness ---

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -30,9 +30,10 @@ cheaper-step = 2
 ; Worker expiry settings
 max-worker-lifetime = 3600
 max-worker-lifetime-delta = 3600
-worker-reload-mercy = 120
-reload-mercy = 120
-harakiri = 0
+worker-reload-mercy = 30
+reload-mercy = 30
+harakiri = 300
+harakiri-verbose = true
 
 ; --- I/O robustness ---
 socket-timeout = 600


### PR DESCRIPTION
## Summary

Fixes multiple related reliability issues causing intermittent 503s and worker saturation on the image server.

### Fork deadlock fix (commits 1-2)
- Replace `sh.convert()` with `subprocess.run()` to eliminate fork deadlocks in multi-threaded uWSGI workers
- Add `close_fds=False` to enable the faster `posix_spawn` path in Python 3.12+

### S3 connection resilience (commits 3-5)
- Fix infinite retry deadlock: `@retry_s3_call` was on every S3 method, causing workers to retry for minutes on transient errors. Now only on client init; request methods fail fast with 503
- Reduce `connect_timeout` to 3s, `read_timeout` to 10s, `max_attempts` to 2
- Fix null-safety in connection pool context managers

### Observability (commit 6)
- Add `/debug/health` endpoint (process stats, no S3/MySQL dependency)
- Add `/debug/pool` endpoint for MySQL pool stats
- Add `RequestTracer` plugin for structured JSON request logging with per-stage timing
- Enable `faulthandler` for crash forensics (SIGSEGV/SIGABRT tracebacks)
- Reduce `harakiri` from 300s to 60s, ImageMagick convert timeout from 120s to 30s

### CLOSE-WAIT connection leak fix (commit 7)
- Root cause of recurring worker saturation: MinIO closes idle connections (FIN), but boto3/urllib3 pool never notices. Sockets go CLOSE-WAIT with unread TLS close_notify in recv_q. Workers that grab stale sockets hang until harakiri kills them. Observed 72 CLOSE-WAIT connections accumulating over 14 hours.
- Fix: Recycle S3 client every 300s to flush stale pooled connections
- Reduce `max_pool_connections` from 64 to 4 (each worker only needs 1-2 concurrent S3 connections)

## Commits
1. `97f5dff` Replace sh.convert() with subprocess.run() to fix fork deadlock
2. `1e5c8da` Add close_fds=False to enable posix_spawn path
3. `27cf0f2` Fix infinite retry deadlock and reduce S3/socket timeouts
4. `f54d27c` Remove S3 retries from request handlers, fail fast with 503
5. `edf2ff8` Fix connection pool context managers to be null-safe
6. `cd6b919` Reduce timeouts and add request tracing / health endpoints
7. `0311748` Fix CLOSE-WAIT connection leak in S3 client pool

## Deployed
All changes deployed to both ibss-images and ibss-images-internal via docker cp + HUP.