### PR TITLE
Fix stale SQLite cache blocking reads of newly-uploaded files

### DIFF
--- a/image_cache.py
+++ b/image_cache.py
@@ -31,6 +31,7 @@ _check_lock = threading.Lock()
 _last_check_monotonic = 0.0
 _CHECK_INTERVAL_S = 10     # how often workers stat() the marker file
 _DEBOUNCE_S = 30           # wait for writes to quiesce before rebuilding
+_MAX_STALENESS_S = 300     # ceiling: rebuild even if marker is still fresh
 
 
 # ── build / rebuild ────────────────────────────────────────────────
@@ -163,6 +164,11 @@ def _needs_rebuild():
         marker_mtime = os.stat(CACHE_INVALIDATE_PATH).st_mtime
     except FileNotFoundError:
         return False
+    # Force rebuild if cache exceeds ceiling — otherwise a steady write
+    # stream keeps the marker fresh and starves rebuilds indefinitely.
+    cache_mtime = os.stat(CACHE_DB_PATH).st_mtime
+    if time.time() - cache_mtime >= _MAX_STALENESS_S:
+        return True
     # Debounce: don't rebuild while writes are still arriving.
     # Only rebuild once the marker is older than _DEBOUNCE_S,
     # meaning writes have quiesced.

--- a/server.py
+++ b/server.py
@@ -431,7 +431,7 @@ def static(path):
     filename = path.split('/')[-1]
     image_db = get_image_db()
     records = cache_get_by_internal_filename(filename)
-    if records is None:
+    if records is None or not records:
         try:
             with db_call_timeout(5):
                 records = image_db.get_image_record_by_internal_filename(filename)
@@ -508,7 +508,7 @@ def fileget():
     image_db = get_image_db()
     with trace_stage('db_lookup'):
         records = cache_get_by_internal_filename(request.query.filename)
-        if records is None:
+        if records is None or not records:
             try:
                 with db_call_timeout(5):
                     records = image_db.get_image_record_by_internal_filename(request.query.filename)


### PR DESCRIPTION
## Summary

During long import batches (e.g. the 8.5K-image botany picturae batch in progress today), `/fileget` returns 404 for every freshly-uploaded file for the entire duration of the import — despite the file being in MinIO and the attachment row being in MySQL. Cause: the SQLite read cache at `/tmp/image_cache.db` never rebuilds during the batch, and the `/fileget` handler doesn't fall back to MySQL when the cache returns an empty result.

### Two layers, two fixes

**1. `image_cache.py` — cap the debounce window.** `_needs_rebuild()` today waits for writes to quiesce for 30s before rebuilding. Each upload touches `/tmp/image_cache.invalidate`, so during an active import the marker is continuously fresh and the debounce window never expires — the cache can be starved indefinitely. Added `_MAX_STALENESS_S = 300`: if the cache file itself is older than 5 minutes, rebuild regardless of marker freshness. Existing `flock` still serializes rebuilds; steady-state behavior is unchanged.

**2. `server.py` — fall back to MySQL on empty cache hits.** `fileget()` and the `/static` handler only fell back to MySQL when `cache_get_by_internal_filename()` returned `None` (cache failure). When the cache returned `[]` (ran successfully but didn't have the row yet), the handler returned 404 without consulting MySQL. Changed `if records is None` to `if records is None or not records` at both call sites. The MySQL lookup is already wrapped in a 5-second `db_call_timeout`, so a hung DB can't stall workers.

Left `cache_get_by_pattern()` at line 768 untouched — empty is a legitimate "no matches" response there, and MySQL `LIKE` fallback has larger cost implications.

## Evidence

Verified on today's in-flight botany picturae import. Traced UUID `1f61ceb0-7d34-4e90-a5c4-f8f28120aab3.jpg`:

- MinIO: file present at `attachments/botany/originals/1f/61/…`, written 13:53
- MySQL `images`: row `id=2244763`, `datetime=2026-04-24 12:53:39`
- SQLite cache: **empty result** — cache's most recent row is `id=2242771` from `07:54`; cache file on disk dated `09:02`
- Cache marker `/tmp/image_cache.invalidate` last touched `14:10` (actively being updated by the running import)
- `GET /fileget?…filename=1f61ceb0…` → `404`

Access-log analysis on the existing nginx logs (Apr 17–24) shows `/fileget` miss rate tracking import days:

| Day | Total /fileget | 404s | Miss rate |
|---|---|---|---|
| Apr 18 | 18,811 | 129 | 0.7% |
| Apr 19 | 19,017 | 119 | 0.6% |
| Apr 20 | 26,537 | 883 | 3.3% |
| **Apr 21** | **43,076** | **8,123** | **18.9%** (200-img test) |
| Apr 22 | 48,204 | 390 | 0.8% |
| Apr 23 | 48,335 | 613 | 1.3% |
| **Apr 24** | **91,715** | **49,767** | **54.3%** (today's 8.5K batch) |

Organic baseline is ~1% — so the extra MySQL lookup the read-path fix adds for legitimate 404s is ~500/day, negligible against the tens of thousands of false 404s it fixes on batch days.

## Test plan

- [x] Diff reviewed locally, mojibake em-dashes corrected (Python byte handling subtlety)
- [ ] `docker compose restart image-server` on ibss-images
- [ ] Re-issue the failing request for `1f61ceb0-7d34-4e90-a5c4-f8f28120aab3.jpg` — expect `200` via MySQL fallback
- [ ] Observe `IMAGE_CACHE rebuilt` in logs within 5 min (the new ceiling firing)
- [ ] Monitor `/fileget` 404 rate in nginx logs over the rest of today's batch — expect return to ~1% baseline
