### PR TITLE
Bring the deployed config into git after fixing a 3.5-month branch drift

### DIFF
--- a/cas-security/cas-security-http.conf
+++ b/cas-security/cas-security-http.conf
@@ -1,0 +1,188 @@
+# cas-security-http.conf
+#
+# MANAGED BY ANSIBLE -- role image-server-defences. Local edits are reverted on
+# the next converge. Change it in the role, not here.
+#
+# Scraper defences for ibss-images, from the 2026-08-02 distributed-scrape and
+# disk-full outage. Split out of nginx.conf because that file is .gitignore'd in
+# the app repo and hand-maintained, so ansible could not own the enforcement.
+# Same approach the crowdsec-client role already uses for monarch.
+#
+# Included from the http{} block. Maps/geos only -- nginx resolves
+# map variables lazily, so definition order does not matter.
+
+    # TLS fingerprint carrier: handshake phase writes fp keyed by client IP,
+    # request phase reads it into $cas_tlsfp for the access log. Best-effort.
+    # lua-resty-ja4 (MIT) mounted from /ibss-alt/lua-resty-ja4/lib
+    lua_package_path "/usr/local/openresty/site/lualib-ja4/?.lua;;";
+
+    lua_shared_dict cas_tlsfp 10m;
+    # --- JA4 TLS fingerprint deny list (added 2026-08-02) ---
+    # Populated ONLY from reviewed cas/scraper-fp-abuse findings: a fingerprint
+    # whose traffic here is >=90% refused across >=50 requests, i.e. one that
+    # nothing legitimate uses. Empty by default -- a JA4 identifies a client
+    # LIBRARY, not an actor, so entries need a human decision.
+    #
+    # Known-bad from the 2026-08-02 scrape, deliberately NOT enabled while the
+    # UA rules still catch 100% of it (see incident todo):
+    #   t13d1712h1_ab0a1bf427ad_8e6e362c5eac   # swarm; Python stack, 1044 IPs
+    map $cas_tlsfp $is_denied_fp {
+        default 0;
+    }
+
+    map "$is_denied_fp:$limit_bot" $block_fp {
+        "1:1" 1;
+        default 0;
+    }
+
+    map $http_user_agent $is_bot {
+        default 0;
+        "~*(CCBot|Googlebot-Images|Sogou|SenutoBot|SiteScoreBot|Twitterbot|YisouSpider|IABot|Turnitin|CFNetwork/.* Darwin|ClaudeBot|SemrushBot|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Exabot|facebot|facebookexternalhit|Bytespider|AppleBot|Swiftbot|Slurp Bot|GoogleOther|Google-InspectionTool|MJ12bot|Alexa crawler|Soso Spider|Pinterestbot|Dotbot|AhrefsBot|archive.org_bot|scrapy|PetalBot|Amazonbot|DataForSeoBot|crawl-66-249-66-200.googlebot.com|rdap.arin.net|meta-externalagent)" 1;
+        # Python HTTP libraries (scrapers)
+        "~*(python-requests|python-urllib|httpx|aiohttp)" 1;
+        # Go/Node.js/Dart HTTP clients (scrapers)
+        "~*(Go-http-client|axios/|Dart/)" 1;
+        # GardenSketchBot (33.5 GB bandwidth abuse)
+        "~*GardenSketchBot" 1;
+        # ML training data scrapers
+        "~*(PlantTrainingDataCollector|PlantRobot-Dataset|PlantDatasetBuilder|BioCLIP|NicheForge)" 1;
+        # Self-identified crawlers
+        "~*\(compatible;\s*crawler\)" 1;
+        # Bare "Mozilla/5.0" with no engine details — real browsers always include more
+        "~^Mozilla/5\.0$" 1;
+        # AWS scraper farm signature (26 IPs, Firefox/72 spoofing)
+        "~*Firefox/72\.0" 1;
+        # Obsolete IE versions (NCATS scanner pattern, general bots)
+        "~*MSIE\s[5-8]\.0" 1;
+        # Ancient Android (<=4.x) — almost always bots
+        "~*Android\s[1-4]\." 1;
+
+        # --- Added 2026-08-02: distributed Botany thumbnail scrape ---
+        # 135k single-request IPs, UAs randomly sampled from a ~2018 list.
+        # Measured against 28.7h of traffic: blocks 79% of external requests,
+        # zero hits on any current browser or known partner.
+        # Chrome/Firefox major version < 100 (three-digit versions do not match).
+        "~*Chrome/\d{1,2}\." 1;
+        "~*Firefox/\d{1,2}\." 1;
+        # Internet Explorer, any version
+        "~*MSIE\s[5-9]\." 1;
+        # Windows XP/Vista/7 (NT 10.0 does not match: digit must be followed by '.')
+        "~*Windows NT [1-6]\." 1;
+        # PowerPC Macs (discontinued 2006) and the pre-2010 "U;" security token
+        "~*PPC Mac" 1;
+        "~*(Macintosh|Windows|X11); U;" 1;
+        # 32-bit Linux desktop
+        "~*Linux i686" 1;
+        # iOS 1-9
+        # iOS 1-9 only. "CPU iPad OS" was NOT covered by the original
+        # (iPhone )? group -- the swarm exploited exactly that gap on
+        # 2026-08-02 to serve itself 254 requests behind iPad UAs. Modern
+        # "OS 17_1" stays safe: [1-9]_ needs a single digit before the _.
+        "~*CPU (iPhone |iPad |iPod )?OS [1-9]_" 1;
+        # Internally impossible UA: an iOS device claiming AppleWebKit/5xx.
+        # Real iOS Safari reports WebKit 605.x; 5xx predates the iPad itself.
+        # The swarm pairs "iPad OS 17_3_1" with "AppleWebKit/535.0" (2011).
+        # Measured 2026-08-02: 93 reqs / 93 distinct IPs (1.00 per IP), zero
+        # internal, and zero genuine iOS clients in the window.
+        "~*(iPhone|iPad|iPod).*AppleWebKit/5" 1;
+        # Named bulk harvesters of full-size originals (55% of server time)
+        "~*(PlantCrawler|Kasagardem|DatasetBuilder|PlantHealthEngine)" 1;
+        "~*^Java/1\." 1;
+    }
+
+    geo $limit_bot {
+        default 1;
+        10.0.0.0/8 0;
+        172.16.0.0/12 0;
+        192.168.0.0/16 0;
+        # GBIF Denmark partner - exempt from UA blocking (Thumbor)
+        130.225.43.0/24 0;
+    }
+
+    # Added 2026-08-02: forged multi-value Referer, e.g.
+    #   "https://google.com, https://www.cch2.org/portal/taxa/index.php?tid=..."
+    # No browser emits a comma-joined Referer. 46,769 requests in 28.7h.
+    map $http_referer $is_forged_referer {
+        default 0;
+        "~,\s*https?://" 1;
+    }
+
+    map "$is_forged_referer:$limit_bot" $block_forged_referer {
+        "1:1" 1;
+        default 0;
+    }
+
+    map "$is_bot:$limit_bot" $block_bot {
+        "1:1" 1;
+        default 0;
+    }
+
+    geo $is_blocked_ip {
+        default 0;
+        47.76.0.0/16 1;
+        66.249.66.200 1;
+        52.224.0.0/11 1;
+        13.200.0.0/13 1;
+        36.110.0.0/16 1;
+        106.36.0.0/15 1;
+        188.166.224.0/20 1;
+        # DigitalOcean ranges (bot/scraper farms)
+        134.122.0.0/15 1;
+        137.184.0.0/14 1;
+        142.93.0.0/16 1;
+        143.198.0.0/15 1;
+        143.244.0.0/16 1;
+        146.190.0.0/15 1;
+        147.182.0.0/15 1;
+        157.230.0.0/15 1;
+        157.245.0.0/16 1;
+        159.65.0.0/16 1;
+        159.89.0.0/16 1;
+        159.203.0.0/16 1;
+        159.223.0.0/16 1;
+        161.35.0.0/16 1;
+        162.243.0.0/16 1;
+        164.90.0.0/16 1;
+        165.22.0.0/15 1;
+        165.227.0.0/16 1;
+        167.71.0.0/16 1;
+        167.99.0.0/16 1;
+        167.172.0.0/16 1;
+        174.138.0.0/16 1;
+        178.128.0.0/16 1;
+        178.62.0.0/16 1;
+        192.241.0.0/16 1;
+        198.199.0.0/16 1;
+        206.189.0.0/16 1;
+        206.81.0.0/16 1;
+        # Frontier/SNET persistent scraper (194K blocked reqs, still hammering)
+        32.220.168.0/21 1;
+
+        # Malta python-requests scraper (305 GB bandwidth abuse)
+        195.158.111.90 1;
+
+        # Packethub S.A. (Panama hosting/VPN, 76.5 GB)
+        193.43.135.0/24 1;
+
+        # AWS us-east-2 scraper farm (26 IPs, Firefox/72 spoofing)
+        3.128.0.0/9 1;
+        18.116.0.0/14 1;
+        18.188.0.0/14 1;
+        18.216.0.0/14 1;
+        18.220.0.0/14 1;
+
+        # Linode/Akamai (rate-limit abuser)
+        45.79.0.0/16 1;
+
+        # IP Volume Netherlands (scanner)
+        89.248.168.0/24 1;
+
+        # Google Cloud scraper ranges
+        34.64.0.0/10 1;
+        8.34.208.0/20 1;
+
+        # OVH datacenter scraper farm (Chrome/139.0.0.0 spoofing, no referer)
+        57.129.0.0/16 1;
+        141.94.0.0/16 1;
+        51.77.0.0/16 1;
+    }

--- a/cas-security/cas-security-server.conf
+++ b/cas-security/cas-security-server.conf
@@ -1,0 +1,126 @@
+# cas-security-server.conf
+#
+# MANAGED BY ANSIBLE -- role image-server-defences. Local edits are reverted on
+# the next converge. Change it in the role, not here.
+#
+# Scraper defences for ibss-images, from the 2026-08-02 distributed-scrape and
+# disk-full outage. Split out of nginx.conf because that file is .gitignore'd in
+# the app repo and hand-maintained, so ansible could not own the enforcement.
+# Same approach the crowdsec-client role already uses for monarch.
+#
+# Included from the server{} block. ORDER MATTERS: set_by_lua must precede
+# the "if (...) return 403" gates -- both run in the rewrite phase in
+# declaration order. (rewrite_by_lua always runs last in that phase, which is
+# why the fingerprint lookup is set_by_lua and not rewrite_by_lua.)
+
+        # --- TLS client fingerprint: canonical JA4 via lua-resty-ja4 (MIT) ---
+        # Emits e.g. t13d1712h1_ab0a1bf427ad_8e6e362c5eac, which is directly
+        # lookupable at https://ja4db.com/. A real browser and a Go/Python/curl
+        # client emit very different ClientHellos no matter what User-Agent they
+        # claim, and a proxy forwards the handshake UNCHANGED -- so the
+        # fingerprint survives IP rotation. That is the one signal a scraper
+        # cannot fix by editing a header.
+        #
+        # Measured 2026-08-02: the swarm's cipher hash matched python3 urllib
+        # exactly. See incidents/2026-08-02-ibss-images-scraper-outage/todo.md.
+        #
+        # Carried to the request by shared dict keyed on client IP -- NOT the
+        # library's ngx.ctx, which does not survive the internal redirect our
+        # 403 path uses. ngx.var is unavailable in the handshake phase; do not
+        # reintroduce it. Everything is wrapped in pcall: a fault here must
+        # degrade to "no fingerprint", never refuse a TLS connection.
+        ssl_client_hello_by_lua_block {
+            -- Canonical JA4 via lua-resty-ja4 (MIT). Emits e.g.
+            -- t13d1516h2_8daaf6152771_e5627efa2ab1, which is directly
+            -- lookupable at https://ja4db.com/ -- unlike the private hash this
+            -- replaced. The library filters GREASE via the official OpenResty
+            -- getters and returns nil+err rather than raising.
+            --
+            -- Still wrapped in pcall: this runs inside the TLS handshake, so a
+            -- fault must degrade to "no fingerprint", never refuse a connection.
+            local ok, err = pcall(function()
+                local ja4 = require "resty.ja4"
+                local ssl = require "ngx.ssl"
+                local dict = ngx.shared.cas_tlsfp
+                if not dict then return end
+
+                ja4.configure({ hash = true })
+                local fp, cerr = ja4.compute()
+                if not fp then
+                    ngx.log(ngx.WARN, "ja4 compute: ", tostring(cerr))
+                    return
+                end
+
+                -- Carry by client IP: ngx.var is unavailable in this phase, and
+                -- the library's ngx.ctx handoff does not survive the internal
+                -- redirect our 403 path uses. raw_client_addr() returns BINARY.
+                local addr, atype = ssl.raw_client_addr()
+                if not addr then return end
+                local key
+                if atype == "inet" and #addr == 4 then
+                    local a, b, c, d = string.byte(addr, 1, 4)
+                    key = string.format("%d.%d.%d.%d", a, b, c, d)
+                elseif atype == "inet6" and #addr == 16
+                       and addr:sub(1, 12) == "\0\0\0\0\0\0\0\0\0\0\255\255" then
+                    local a, b, c, d = string.byte(addr, 13, 16)
+                    key = string.format("%d.%d.%d.%d", a, b, c, d)
+                else
+                    return
+                end
+                dict:set(key, fp, 600)
+            end)
+            if not ok then
+                ngx.log(ngx.WARN, "cas_tlsfp_error: ", tostring(err))
+            end
+        }
+        # set_by_lua, NOT rewrite_by_lua: the blocking "if (...) return 403"
+        # directives below run in the rewrite phase BEFORE rewrite_by_lua (which
+        # nginx runs last in that phase), so a rewrite_by_lua lookup never executed
+        # for blocked requests -- exactly the ones the scrape detector needs.
+        # set_by_lua runs inline with the rewrite-module script in declaration
+        # order, i.e. before those ifs.
+        set_by_lua_block $cas_tlsfp {
+            local ok, fp = pcall(function()
+                local dict = ngx.shared.cas_tlsfp
+                if not dict then return nil end
+                return dict:get(ngx.var.remote_addr or "")
+            end)
+            return (ok and fp) or "-"
+        }
+        # Override botblocker for whitelisted Thumbor (Danish partners)
+        if ($thumbor_whitelist) {
+            # $bad_bot belonged to the Nginx Ultimate Bad Bot Blocker, retired in
+            # a74df37 -- clearing it alone was a no-op. $block_bot is what the
+            # "return 403" below actually reads.
+            set $bad_bot '0';
+            set $block_bot '0';
+        }
+
+        # Always allow /robots.txt — crawlers must be able to read disallow rules
+        if ($request_uri ~ ^/robots\.txt) {
+            set $bad_bot '0';
+            set $bad_words '0';
+            set $bad_referer '0';
+            set $validate_client '0';
+            set $block_bot '0';
+            set $is_blocked_ip '0';
+            set $block_forged_referer '0';
+            set $block_fp '0';
+        }
+
+
+        if ($block_bot) {
+            return 403;
+        }
+
+        if ($block_forged_referer) {
+            return 403;
+        }
+
+        if ($block_fp) {
+            return 403;
+        }
+
+        if ($is_blocked_ip) {
+            return 403;
+        }

--- a/collection_definitions.py
+++ b/collection_definitions.py
@@ -14,6 +14,7 @@ COLLECTION_DIRS = {
     'Invertebrate Zoology': 'iz',
     'IZ': 'iz',
     'casiz': 'iz',
-    'Botany_PIC': 'PIC_upload'
+    'Botany_PIC': 'PIC_upload',
+    'casherp': 'herp'
 }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,8 +35,14 @@ http {
         '"http_user_agent":"$http_user_agent",'
         '"upstream_addr":"$upstream_addr",'
         '"upstream_status":"$upstream_status",'
-        '"http_x_forwarded_for":"$http_x_forwarded_for"'
+        '"http_x_forwarded_for":"$http_x_forwarded_for",'
+        '"conn":"$connection",'
+        '"tls_fp":"$cas_tlsfp"'
     '}';
+
+    # Scraper defences (maps/geos) -- ansible-owned, see role
+    # image-server-defences. Do not inline these back into this file.
+    include /usr/local/openresty/nginx/conf/cas-security/cas-security-http.conf;
 
     sendfile                 on;
     tcp_nopush               on;
@@ -100,114 +106,6 @@ http {
     "~[\r\n]" "bad_xff";
     }
 
-    map $http_user_agent $is_bot {
-        default 0;
-        "~*(CCBot|Googlebot-Images|Sogou|SenutoBot|SiteScoreBot|Twitterbot|YisouSpider|IABot|Turnitin|
-        CFNetwork/.* Darwin|ClaudeBot|SemrushBot|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Sogou|Exabot|
-        facebot|facebookexternalhit|Bytespider|AppleBot|Swiftbot|Slurp Bot|CCBot|GoogleOther|Google-InspectionTool|
-        MJ12bot|Alexa crawler|Soso Spider|Pinterestbot|Dotbot|AhrefsBot|archive.org_bot|scrapy|PetalBot|
-        SemrushBot|Amazonbot|DataForSeoBot|crawl-66-249-66-200.googlebot.com|rdap.arin.net|meta-externalagent)" 1;
-        # Python HTTP libraries (scrapers)
-        "~*(python-requests|python-urllib|httpx|aiohttp)" 1;
-        # Go/Node.js/Dart HTTP clients (scrapers)
-        "~*(Go-http-client|axios/|Dart/)" 1;
-        # GardenSketchBot (33.5 GB bandwidth abuse)
-        "~*GardenSketchBot" 1;
-        # ML training data scrapers
-        "~*(PlantTrainingDataCollector|PlantRobot-Dataset|PlantDatasetBuilder|BioCLIP|NicheForge)" 1;
-        # Self-identified crawlers
-        "~*\(compatible;\s*crawler\)" 1;
-        # Bare "Mozilla/5.0" with no engine details — real browsers always include more
-        "~^Mozilla/5\.0$" 1;
-        # AWS scraper farm signature (26 IPs, Firefox/72 spoofing)
-        "~*Firefox/72\.0" 1;
-        # Obsolete IE versions (NCATS scanner pattern, general bots)
-        "~*MSIE\s[5-8]\.0" 1;
-        # Ancient Android (<=4.x) — almost always bots
-        "~*Android\s[1-4]\." 1;
-    }
-
-    geo $limit_bot {
-        default 1;
-        10.0.0.0/8 0;
-        172.16.0.0/12 0;
-        192.168.0.0/16 0;
-    }
-
-    map "$is_bot:$limit_bot" $block_bot {
-        "1:1" 1;
-        default 0;
-    }
-
-    geo $is_blocked_ip {
-        default 0;
-        47.76.0.0/16 1;
-        66.249.66.200 1;
-        52.224.0.0/11 1;
-        13.200.0.0/13 1;
-        36.110.0.0/16 1;
-        106.36.0.0/15 1;
-        188.166.224.0/20 1;
-        # DigitalOcean ranges (bot/scraper farms)
-        134.122.0.0/15 1;
-        137.184.0.0/14 1;
-        142.93.0.0/16 1;
-        143.198.0.0/15 1;
-        143.244.0.0/16 1;
-        146.190.0.0/15 1;
-        147.182.0.0/15 1;
-        157.230.0.0/15 1;
-        157.245.0.0/16 1;
-        159.65.0.0/16 1;
-        159.89.0.0/16 1;
-        159.203.0.0/16 1;
-        159.223.0.0/16 1;
-        161.35.0.0/16 1;
-        162.243.0.0/16 1;
-        164.90.0.0/16 1;
-        165.22.0.0/15 1;
-        165.227.0.0/16 1;
-        167.71.0.0/16 1;
-        167.99.0.0/16 1;
-        167.172.0.0/16 1;
-        174.138.0.0/16 1;
-        178.128.0.0/16 1;
-        178.62.0.0/16 1;
-        192.241.0.0/16 1;
-        198.199.0.0/16 1;
-        206.189.0.0/16 1;
-        206.81.0.0/16 1;
-        # Frontier/SNET persistent scraper (194K blocked reqs, still hammering)
-        32.220.168.0/21 1;
-
-        # Malta python-requests scraper (305 GB bandwidth abuse)
-        195.158.111.90 1;
-
-        # Packethub S.A. (Panama hosting/VPN, 76.5 GB)
-        193.43.135.0/24 1;
-
-        # AWS us-east-2 scraper farm (26 IPs, Firefox/72 spoofing)
-        3.128.0.0/9 1;
-        18.116.0.0/14 1;
-        18.188.0.0/14 1;
-        18.216.0.0/14 1;
-        18.220.0.0/14 1;
-
-        # Linode/Akamai (rate-limit abuser)
-        45.79.0.0/16 1;
-
-        # IP Volume Netherlands (scanner)
-        89.248.168.0/24 1;
-
-        # Google Cloud scraper ranges
-        34.64.0.0/10 1;
-        8.34.208.0/20 1;
-
-        # OVH datacenter scraper farm (Chrome/139.0.0.0 spoofing, no referer)
-        57.129.0.0/16 1;
-        141.94.0.0/16 1;
-        51.77.0.0/16 1;
-    }
 
     geo $limited {
         default 1;
@@ -274,9 +172,18 @@ http {
         default $final_limit;
     }
 
-    # Thumbnail zone: 120 req/min per IP, burst 120 (thumbnails fully exempt)
-    # Thumbnails bypass all rate limiting (empty key via $fullsize_limit)
-    limit_req_zone $fullsize_limit zone=thumb_zone:10m rate=120r/m;
+    # Thumbnail rate-limit key: thumbnails keyed per-IP, everything else exempt
+    # from THIS zone (it is governed by fullsize_zone instead).
+    # Fixed 2026-08-02: previously keyed on $fullsize_limit, which is "" for
+    # type=T -- an empty key disables limit_req, so this zone was dead code and
+    # thumbnails were entirely unlimited.
+    map $arg_type $thumb_limit {
+        "T"     $final_limit;
+        default "";
+    }
+
+    # Thumbnail zone: 120 req/min per IP, burst 120
+    limit_req_zone $thumb_limit zone=thumb_zone:10m rate=120r/m;
 
     # Full-size zone: stricter (10 req/min per IP, burst 5)
     # Only applies to non-thumbnail requests (key is "" for thumbnails)
@@ -294,6 +201,11 @@ http {
 
     server {
         listen 443 ssl;
+
+        # Scraper defences (handshake fingerprint + 403 gates) -- ansible-owned,
+        # see role image-server-defences. ORDER-SENSITIVE, keep this include
+        # before any other rewrite-phase directive that depends on $cas_tlsfp.
+        include /usr/local/openresty/nginx/conf/cas-security/cas-security-server.conf;
         server_name _;
 
         uwsgi_buffer_size 128k;
@@ -301,9 +213,23 @@ http {
         uwsgi_busy_buffers_size 256k;
         ssl_certificate /etc/ssl/certs/wildcard_calacademy_org.pem;
         ssl_certificate_key /etc/ssl/private/wildcard_calacademy_org.key;
+        # BEGIN ANSIBLE MANAGED cas-wellknown-notice
+# Managed by ansible (crowdsec-client role) — RFC 9116 security.txt + access
+# policy for blocked-by-default automated clients (datacenter feed, AI crawlers).
+# Expires snaps to 90-day buckets so weekly runs stay changed=0 between quarters.
+location = /.well-known/security.txt {
+    default_type text/plain;
+    return 200 "# California Academy of Sciences — Scientific Computing\nContact: mailto:jrussack@calacademy.org\nExpires: 2027-06-05T00:00:00Z\nPolicy: https://ibss-images.calacademy.org/access-policy.txt\nPreferred-Languages: en\n";
+}
+location = /access-policy.txt {
+    default_type text/plain;
+    return 200 "California Academy of Sciences — Collections Web Services\nAccess policy for automated and bulk clients\n=============================================================\n\nConnections from datacenter, cloud-hosting, and VPN address space\nare blocked by default on this and related calacademy.org research\nservices. This measure exists because of sustained bulk-scraping\nfrom rotating cloud servers, which has degraded service for\nresearchers and the public.\n\nIf you are operating a legitimate service from cloud infrastructure\nand need access, email jrussack@calacademy.org with:\n\n  - the IP address(es) or CIDR range(s) your service uses\n  - your organization and the purpose of the access\n  - which endpoints you need and your expected request rate\n\nApproved ranges are added to a standing allowlist, typically within\na few business days.\n\nBefore requesting access, note that most bulk-data needs are already\nserved without scraping:\n\n  - Specimen occurrence records and images are published to GBIF\n    (https://www.gbif.org/publisher/search?q=california%20academy)\n    as Darwin Core Archives — complete, versioned, citable.\n  - Fish taxonomy: Eschmeyer's Catalog of Fishes at\n    https://researcharchive.calacademy.org/\n\nAI/LLM training crawlers: see robots.txt. Crawling for model\ntraining is not permitted without prior written arrangement via\nthe same contact.\n";
+}
+        # END ANSIBLE MANAGED cas-wellknown-notice
 
         # Decode HTML-encoded ampersands in query strings (&amp; → &)
         # Some clients (crawlers, double-encoded links) send &amp; literally.
+
         rewrite_by_lua_block {
             local args = ngx.var.args
             if args and args:find("&amp;", 1, true) then
@@ -311,29 +237,6 @@ http {
             end
         }
 
-        # Override botblocker for whitelisted Thumbor (Danish partners)
-        if ($thumbor_whitelist) {
-            set $bad_bot '0';
-        }
-
-        # Always allow /robots.txt — crawlers must be able to read disallow rules
-        if ($request_uri ~ ^/robots\.txt) {
-            set $bad_bot '0';
-            set $bad_words '0';
-            set $bad_referer '0';
-            set $validate_client '0';
-            set $block_bot '0';
-            set $is_blocked_ip '0';
-        }
-
-
-        if ($block_bot) {
-            return 403;
-        }
-
-        if ($is_blocked_ip) {
-            return 403;
-        }
 
         # Custom error pages for blocked and rate-limited requests
         error_page 403 /403.html;

--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -1,3 +1,23 @@
+# =============================================================================
+# !! SUPERSEDED -- DO NOT REGENERATE nginx.conf FROM THIS FILE !!
+#
+# Last meaningful update 2026-03-03. The live nginx.conf has diverged by ~280
+# lines since and is the real source of truth. Regenerating from this template
+# would silently revert FIVE MONTHS of security work, including:
+#   * the $is_bot user-agent blocklist and $is_blocked_ip ranges
+#   * the July AI-crawler block and the CrowdSec AppSec lua hook
+#   * the 2026-08-02 scraper defences (JA4 fingerprinting, forged-referer gate,
+#     impossible-client rules) -- see the cas-security/ drop-ins, which are
+#     ansible-owned by role image-server-defences
+#   * the repaired thumbnail rate-limit key
+#
+# Nothing consumes this file automatically (Dockerfile.nginx copies nginx.conf,
+# not this), so it is inert -- but it is a trap for anyone who trusts the name.
+#
+# If you want a maintainable split, the security half already lives in
+# cas-security/*.conf under ansible. Extend that, not this.
+# =============================================================================
+
 # OpenResty-based nginx.conf
 worker_processes 1;
 


### PR DESCRIPTION
## Why

`ibss-images` had been serving from the merged-and-abandoned branch
`fix-stale-cache-blocks-new-uploads` since its PR (#87) merged on **2026-04-24**.
The deployed working copy was never switched back to master.

**Production ran without the stale-cache fix for ~3.5 months.** Verified inside the
running container before the fix: `server.py` lacked the `records is None or not records`
guard and `image_cache.py` lacked `_MAX_STALENESS_S` — i.e. the exact bug #87 fixed,
where an empty cache result never fell through to the database and newly-uploaded
images failed to read.

Two further consequences:

* Security work committed on 2026-07-09 landed on the dead branch (`6036bf9`, `a74df37`),
  was re-done on master as `db2cb85`/`488e7cf` (verified **identical trees**), and a third
  copy (`e64c890`) sat on the stale local master. Nobody moved the deployment.
* `499ae6a` ("track the real deployed nginx.conf") never reached production, so nginx.conf
  stayed gitignored there and the deployed config had no version history.

## What this contains

The deployment has been reset to `origin/master` (stale-cache fix confirmed live in the
container). This commit captures the deployed state that existed only on disk:

| File | |
|---|---|
| `nginx.conf` | the deployed config, incl. the 2026-08-02 scraper defences, now carrying two `include` lines |
| `cas-security/*.conf` | those defences. **Ansible is authoritative** (role `image-server-defences`); these copies exist so a fresh deploy works, since an nginx `include` of a missing file is fatal |
| `collection_definitions.py` | `'casherp': 'herp'` — live but uncommitted since 2026-06-16 |
| `nginx.template.conf` | marked SUPERSEDED: ~280 lines stale, regenerating from it would have reverted months of security work |

## Notes for review

* `cas-security/*.conf` carry a header saying ansible reverts local edits. Change them in
  the role, not here.
* The dead branch has been deleted locally; deleting it on the remote is proposed separately.
* Background: `incidents/2026-08-02-ibss-images-scraper-outage/todo.md` in the infrastructure repo.
