### PR TITLE
cas-security: track the meta-webindexer block already deployed

### DIFF
--- a/cas-security/cas-security-http.conf
+++ b/cas-security/cas-security-http.conf
@@ -37,7 +37,7 @@
 
     map $http_user_agent $is_bot {
         default 0;
-        "~*(CCBot|Googlebot-Images|Sogou|SenutoBot|SiteScoreBot|Twitterbot|YisouSpider|IABot|Turnitin|CFNetwork/.* Darwin|ClaudeBot|SemrushBot|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Exabot|facebot|facebookexternalhit|Bytespider|AppleBot|Swiftbot|Slurp Bot|GoogleOther|Google-InspectionTool|MJ12bot|Alexa crawler|Soso Spider|Pinterestbot|Dotbot|AhrefsBot|archive.org_bot|scrapy|PetalBot|Amazonbot|DataForSeoBot|crawl-66-249-66-200.googlebot.com|rdap.arin.net|meta-externalagent)" 1;
+        "~*(CCBot|Googlebot-Images|Sogou|SenutoBot|SiteScoreBot|Twitterbot|YisouSpider|IABot|Turnitin|CFNetwork/.* Darwin|ClaudeBot|SemrushBot|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Exabot|facebot|facebookexternalhit|Bytespider|AppleBot|Swiftbot|Slurp Bot|GoogleOther|Google-InspectionTool|MJ12bot|Alexa crawler|Soso Spider|Pinterestbot|Dotbot|AhrefsBot|archive.org_bot|scrapy|PetalBot|Amazonbot|DataForSeoBot|crawl-66-249-66-200.googlebot.com|rdap.arin.net|meta-externalagent|meta-webindexer)" 1;
         # Python HTTP libraries (scrapers)
         "~*(python-requests|python-urllib|httpx|aiohttp)" 1;
         # Go/Node.js/Dart HTTP clients (scrapers)


### PR DESCRIPTION
## What

One token. Adds `meta-webindexer` to the `$is_bot` alternation in `cas-security/cas-security-http.conf`, matching what is **already running** on ibss-images.

## Why this is not cosmetic

The block was deployed via ansible (role `image-server-defences`, ibss-ansible `9fc017c`) on 2026-08-06, but never landed in this repo — so the tracked copy of this file was one token behind production.

That gap is a live hazard. This file is bind-mounted into `bottle-nginx` from the deployed working copy at `/ibss-alt/cas-web-asset-server`. A `git reset --hard` or `git checkout .` there — which is exactly what the 2026-08-02 incident response did — would revert this file on disk and **silently un-block Meta's crawler** until the next weekly ansible converge. A container recreate inside that window would put the unblocked config into service.

This is the same deployed-vs-git drift that left production running a dead branch for 3.5 months (see #88).

## Risk

**None.** Ansible already deploys this exact content; the running config is unchanged either way. This only makes git match reality. Verified after merge: `ansible-playbook image_server_app.yml --limit ibss-images` reports `changed=0`.

## Context

`meta-webindexer/1.1` took **76,239 Botany thumbnails in a single day** while ignoring a robots.txt that disallows all bots. `meta-externalagent` was already in the blocklist; `meta-webindexer` was not. `facebookexternalhit` is unaffected by this change (it was already blocked, separately).
